### PR TITLE
fix: child controllers must use internal Service URL, not Status.URL

### DIFF
--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -29,6 +29,16 @@ import (
 	sonarqubev1alpha1 "github.com/BEIRDINH0S/sonarqube-operator/api/v1alpha1"
 )
 
+// instanceAPIURL returns the in-cluster URL the operator must use to call the
+// SonarQube HTTP API. It is always the internal Service URL — independent of
+// whether spec.ingress is enabled. The ingress is for external clients
+// (browsers, CI tools); internal API calls from the operator must go through
+// the cluster Service so they don't depend on cluster-external networking,
+// which is typically not reachable from inside the operator pod.
+func instanceAPIURL(instance *sonarqubev1alpha1.SonarQubeInstance) string {
+	return fmt.Sprintf("http://%s.%s:9000", instance.Name, instance.Namespace)
+}
+
 // getInstanceAdminToken lit le token Bearer admin depuis le Secret référencé par instance.Status.AdminTokenSecretRef.
 func getInstanceAdminToken(ctx context.Context, k8sClient client.Client, instance *sonarqubev1alpha1.SonarQubeInstance) (string, error) {
 	if instance.Status.AdminTokenSecretRef == "" {

--- a/internal/controller/sonarqubeinstance_controller.go
+++ b/internal/controller/sonarqubeinstance_controller.go
@@ -109,7 +109,7 @@ func (r *SonarQubeInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("reconciling Ingress: %w", err)
 	}
 
-	serviceURL := fmt.Sprintf("http://%s.%s:9000", instance.Name, instance.Namespace)
+	serviceURL := instanceAPIURL(instance)
 	result := r.reconcileHealth(ctx, instance, serviceURL)
 
 	if instance.Spec.Ingress.Enabled && instance.Spec.Ingress.Host != "" {

--- a/internal/controller/sonarqubeplugin_controller.go
+++ b/internal/controller/sonarqubeplugin_controller.go
@@ -125,7 +125,7 @@ func (r *SonarQubePluginReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		_ = r.Status().Update(ctx, plugin)
 		return ctrl.Result{RequeueAfter: requeueAfterHealthCheck}, nil
 	}
-	sonarClient := r.NewSonarClient(instance.Status.URL, token)
+	sonarClient := r.NewSonarClient(instanceAPIURL(instance), token)
 
 	// Ajouter le finalizer si absent
 	if !controllerutil.ContainsFinalizer(plugin, pluginFinalizer) {
@@ -150,7 +150,7 @@ func (r *SonarQubePluginReconciler) finalizeDeletion(ctx context.Context, plugin
 
 	if instance.Status.Phase == phaseReady {
 		if token, err := getInstanceAdminToken(ctx, r.Client, instance); err == nil {
-			sonarClient := r.NewSonarClient(instance.Status.URL, token)
+			sonarClient := r.NewSonarClient(instanceAPIURL(instance), token)
 			return r.handleDeletion(ctx, plugin, sonarClient, instance)
 		}
 	}

--- a/internal/controller/sonarqubeproject_controller.go
+++ b/internal/controller/sonarqubeproject_controller.go
@@ -123,7 +123,7 @@ func (r *SonarQubeProjectReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		_ = r.Status().Update(ctx, project)
 		return ctrl.Result{RequeueAfter: requeueAfterHealthCheck}, nil
 	}
-	sonarClient := r.NewSonarClient(instance.Status.URL, token)
+	sonarClient := r.NewSonarClient(instanceAPIURL(instance), token)
 
 	if !controllerutil.ContainsFinalizer(project, projectFinalizer) {
 		controllerutil.AddFinalizer(project, projectFinalizer)
@@ -152,7 +152,7 @@ func (r *SonarQubeProjectReconciler) finalizeDeletion(ctx context.Context, proje
 
 	if instance.Status.Phase == phaseReady {
 		if token, err := getInstanceAdminToken(ctx, r.Client, instance); err == nil {
-			sonarClient := r.NewSonarClient(instance.Status.URL, token)
+			sonarClient := r.NewSonarClient(instanceAPIURL(instance), token)
 			return r.handleDeletion(ctx, project, sonarClient)
 		}
 	}

--- a/internal/controller/sonarqubequalitygate_controller.go
+++ b/internal/controller/sonarqubequalitygate_controller.go
@@ -122,7 +122,7 @@ func (r *SonarQubeQualityGateReconciler) Reconcile(ctx context.Context, req ctrl
 		_ = r.Status().Update(ctx, gate)
 		return ctrl.Result{RequeueAfter: requeueAfterHealthCheck}, nil
 	}
-	sonarClient := r.NewSonarClient(instance.Status.URL, token)
+	sonarClient := r.NewSonarClient(instanceAPIURL(instance), token)
 
 	if !controllerutil.ContainsFinalizer(gate, qualityGateFinalizer) {
 		controllerutil.AddFinalizer(gate, qualityGateFinalizer)
@@ -146,7 +146,7 @@ func (r *SonarQubeQualityGateReconciler) finalizeDeletion(ctx context.Context, g
 
 	if instance.Status.Phase == phaseReady {
 		if token, err := getInstanceAdminToken(ctx, r.Client, instance); err == nil {
-			sonarClient := r.NewSonarClient(instance.Status.URL, token)
+			sonarClient := r.NewSonarClient(instanceAPIURL(instance), token)
 			return r.handleDeletion(ctx, gate, sonarClient)
 		}
 	}

--- a/internal/controller/sonarqubeuser_controller.go
+++ b/internal/controller/sonarqubeuser_controller.go
@@ -121,7 +121,7 @@ func (r *SonarQubeUserReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		_ = r.Status().Update(ctx, user)
 		return ctrl.Result{RequeueAfter: requeueAfterHealthCheck}, nil
 	}
-	sonarClient := r.NewSonarClient(instance.Status.URL, token)
+	sonarClient := r.NewSonarClient(instanceAPIURL(instance), token)
 
 	if !controllerutil.ContainsFinalizer(user, userFinalizer) {
 		controllerutil.AddFinalizer(user, userFinalizer)
@@ -145,7 +145,7 @@ func (r *SonarQubeUserReconciler) finalizeDeletion(ctx context.Context, user *so
 
 	if instance.Status.Phase == phaseReady {
 		if token, err := getInstanceAdminToken(ctx, r.Client, instance); err == nil {
-			sonarClient := r.NewSonarClient(instance.Status.URL, token)
+			sonarClient := r.NewSonarClient(instanceAPIURL(instance), token)
 			return r.handleDeletion(ctx, user, sonarClient)
 		}
 	}


### PR DESCRIPTION
## Summary

Fix a regression where every Project / QualityGate / User / Plugin
reconciliation failed with `dial tcp: connect: connection refused` as
soon as a `SonarQubeInstance` had `spec.ingress.enabled: true`.

## Root cause

`instance.Status.URL` has two intended consumers:
1. **Users** — they read it from `kubectl get sonarqubeinstance` to know
   where to point their browser. When `spec.ingress` is on, this is the
   public ingress URL (e.g. `http://sonarqube.example.com`).
2. **The operator's own child controllers** — they were also reading
   `Status.URL` to build the SonarQube API client used during
   reconciliation.

These two purposes conflict: the public URL is not necessarily reachable
from inside the operator pod (in this case it resolved back to the pod's
own loopback address, hence the connection refused). Internal API calls
should always go through the in-cluster Service.

## Fix

- New helper `instanceAPIURL(instance)` in `internal/controller/helpers.go`
  that always returns `http://<name>.<ns>:9000` regardless of ingress state.
- All four child controllers (`sonarqubeplugin`, `sonarqubeproject`,
  `sonarqubequalitygate`, `sonarqubeuser`) now build their SonarQube API
  client via this helper.
- `sonarqubeinstance_controller.go` reuses the same helper for its
  internal `serviceURL` to centralize the formula.
- `Status.URL` keeps its user-facing meaning. In particular,
  `SonarQubeProject.Status.ProjectURL` (the clickable dashboard link
  surfaced via `kubectl`) is intentionally left using `Status.URL` — it
  is meant for human eyes, not the operator's HTTP client.

## Test plan

- [x] `go build ./...` clean
- [x] Verified live in a kind cluster: with `spec.ingress.enabled: true`
      and a working ingress controller, after this fix
      `SonarQubeInstance`, `SonarQubeQualityGate`, `SonarQubeProject`,
      and `SonarQubeUser` all reach `phase: Ready` (previously every
      child stayed in `Pending` with connection-refused errors).
- [ ] `make test` — unit suite (Ginkgo) — to run in CI; existing tests
      stub `NewSonarClient` with `func(_, _ string) ...` and ignore the
      URL argument, so they should be unaffected.

## Note on `SonarQubePlugin`

The plugin controller is also fixed for connectivity, but a separate
SonarQube-side issue still blocks plugin install on a fresh instance:
SonarQube requires `POST /api/plugins/risk_consent` (admin) before any
marketplace plugin can be installed. That's worth handling in a
follow-up — either a one-time call during instance bootstrap or a
`spec.pluginsRiskConsent` field on `SonarQubeInstance`.