### PR TITLE
fix(project): reconcile mainBranch field against SonarQube

### DIFF
--- a/internal/controller/sonarqubeinstance_controller_test.go
+++ b/internal/controller/sonarqubeinstance_controller_test.go
@@ -50,14 +50,18 @@ type mockSonarClient struct {
 	lastInstalledVersion string
 	uninstallPluginCalls int
 	// project
-	getProjectResult       *sonarqube.Project
-	getProjectErr          error
-	createProjectCalls     int
-	deleteProjectCalls     int
-	assignQualityGateCalls int
-	generateTokenResult    *sonarqube.Token
-	generateTokenErr       error
-	revokeTokenCalls       int
+	getProjectResult            *sonarqube.Project
+	getProjectErr               error
+	createProjectCalls          int
+	deleteProjectCalls          int
+	assignQualityGateCalls      int
+	generateTokenResult         *sonarqube.Token
+	generateTokenErr            error
+	revokeTokenCalls            int
+	getProjectMainBranchResult  string
+	getProjectMainBranchErr     error
+	renameMainBranchCalls       int
+	lastRenamedMainBranch       string
 	// auth
 	validateAuthErr error
 	// quality gate
@@ -119,6 +123,14 @@ func (m *mockSonarClient) DeleteProject(_ context.Context, _ string) error {
 	return nil
 }
 func (m *mockSonarClient) UpdateProjectVisibility(_ context.Context, _, _ string) error { return nil }
+func (m *mockSonarClient) GetProjectMainBranch(_ context.Context, _ string) (string, error) {
+	return m.getProjectMainBranchResult, m.getProjectMainBranchErr
+}
+func (m *mockSonarClient) RenameMainBranch(_ context.Context, _, branchName string) error {
+	m.renameMainBranchCalls++
+	m.lastRenamedMainBranch = branchName
+	return nil
+}
 func (m *mockSonarClient) ListQualityGates(_ context.Context) ([]sonarqube.QualityGate, error) {
 	return m.listQualityGatesResult, nil
 }

--- a/internal/controller/sonarqubeinstance_controller_test.go
+++ b/internal/controller/sonarqubeinstance_controller_test.go
@@ -50,18 +50,18 @@ type mockSonarClient struct {
 	lastInstalledVersion string
 	uninstallPluginCalls int
 	// project
-	getProjectResult            *sonarqube.Project
-	getProjectErr               error
-	createProjectCalls          int
-	deleteProjectCalls          int
-	assignQualityGateCalls      int
-	generateTokenResult         *sonarqube.Token
-	generateTokenErr            error
-	revokeTokenCalls            int
-	getProjectMainBranchResult  string
-	getProjectMainBranchErr     error
-	renameMainBranchCalls       int
-	lastRenamedMainBranch       string
+	getProjectResult           *sonarqube.Project
+	getProjectErr              error
+	createProjectCalls         int
+	deleteProjectCalls         int
+	assignQualityGateCalls     int
+	generateTokenResult        *sonarqube.Token
+	generateTokenErr           error
+	revokeTokenCalls           int
+	getProjectMainBranchResult string
+	getProjectMainBranchErr    error
+	renameMainBranchCalls      int
+	lastRenamedMainBranch      string
 	// auth
 	validateAuthErr error
 	// quality gate

--- a/internal/controller/sonarqubeproject_controller.go
+++ b/internal/controller/sonarqubeproject_controller.go
@@ -192,6 +192,13 @@ func (r *SonarQubeProjectReconciler) reconcileProject(ctx context.Context, proje
 		}
 	}
 
+	// Reconcile main branch if specified.
+	if project.Spec.MainBranch != "" {
+		if err := r.reconcileMainBranch(ctx, project, sonarClient); err != nil {
+			return err
+		}
+	}
+
 	// Associer le Quality Gate si défini
 	if project.Spec.QualityGateRef != "" {
 		if err := sonarClient.AssignQualityGate(ctx, project.Spec.Key, project.Spec.QualityGateRef); err != nil {
@@ -216,6 +223,34 @@ func (r *SonarQubeProjectReconciler) reconcileProject(ctx context.Context, proje
 		ObservedGeneration: project.Generation,
 	})
 	return r.Status().Update(ctx, project)
+}
+
+// reconcileMainBranch fetches the current main branch from SonarQube and renames it
+// if it doesn't match spec.mainBranch. Errors are non-fatal: a warning event is emitted
+// and reconciliation continues so the project doesn't get stuck in Failed.
+func (r *SonarQubeProjectReconciler) reconcileMainBranch(ctx context.Context, project *sonarqubev1alpha1.SonarQubeProject, sonarClient sonarqube.Client) error {
+	log := logf.FromContext(ctx)
+
+	current, err := sonarClient.GetProjectMainBranch(ctx, project.Spec.Key)
+	if err != nil {
+		r.Recorder.Event(project, corev1.EventTypeWarning, "MainBranchFetchFailed", err.Error())
+		log.Info("Could not fetch main branch, skipping rename", "error", err.Error())
+		return nil
+	}
+
+	if current == project.Spec.MainBranch {
+		return nil
+	}
+
+	if err := sonarClient.RenameMainBranch(ctx, project.Spec.Key, project.Spec.MainBranch); err != nil {
+		r.Recorder.Event(project, corev1.EventTypeWarning, "MainBranchRenameFailed", err.Error())
+		log.Info("Could not rename main branch", "from", current, "to", project.Spec.MainBranch, "error", err.Error())
+		return nil
+	}
+
+	r.Recorder.Event(project, corev1.EventTypeNormal, "MainBranchRenamed",
+		fmt.Sprintf("Main branch renamed from %q to %q", current, project.Spec.MainBranch))
+	return nil
 }
 
 // reconcileCIToken ensures the CI token Secret is present and up to date.

--- a/internal/controller/sonarqubeproject_controller_test.go
+++ b/internal/controller/sonarqubeproject_controller_test.go
@@ -358,6 +358,51 @@ var _ = Describe("SonarQubeProject Controller", func() {
 		Expect(string(secret.Data["token"])).To(Equal("sqp_expiry"))
 	})
 
+	It("renomme la branche principale si elle diffère du spec", func() {
+		instanceName := "proj-instance-branch"
+		projectName := "proj-branch"
+		nn := types.NamespacedName{Name: projectName, Namespace: "default"}
+		defer deleteProject(projectName)
+		defer deleteInstanceIfExists(instanceName)
+
+		newReadyInstance(ctx, instanceName)
+		p := newTestProject(projectName, instanceName, "proj-branch-key")
+		p.Spec.MainBranch = "develop"
+		Expect(k8sClient.Create(ctx, p)).To(Succeed())
+
+		mock := &mockSonarClient{
+			getProjectResult:           &sonarqube.Project{Key: "proj-branch-key", Visibility: "private"},
+			getProjectMainBranchResult: "main",
+		}
+		_, err := newProjectReconciler(mock).Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(mock.renameMainBranchCalls).To(Equal(1))
+		Expect(mock.lastRenamedMainBranch).To(Equal("develop"))
+	})
+
+	It("ne renomme pas la branche principale si elle correspond déjà au spec", func() {
+		instanceName := "proj-instance-branch-noop"
+		projectName := "proj-branch-noop"
+		nn := types.NamespacedName{Name: projectName, Namespace: "default"}
+		defer deleteProject(projectName)
+		defer deleteInstanceIfExists(instanceName)
+
+		newReadyInstance(ctx, instanceName)
+		p := newTestProject(projectName, instanceName, "proj-branch-noop-key")
+		p.Spec.MainBranch = "main"
+		Expect(k8sClient.Create(ctx, p)).To(Succeed())
+
+		mock := &mockSonarClient{
+			getProjectResult:           &sonarqube.Project{Key: "proj-branch-noop-key", Visibility: "private"},
+			getProjectMainBranchResult: "main",
+		}
+		_, err := newProjectReconciler(mock).Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(mock.renameMainBranchCalls).To(Equal(0))
+	})
+
 	It("supprime le projet SonarQube à la suppression de la ressource", func() {
 		instanceName := "proj-instance-delete"
 		projectName := "proj-delete"

--- a/internal/controller/sonarqubeproject_controller_test.go
+++ b/internal/controller/sonarqubeproject_controller_test.go
@@ -403,6 +403,34 @@ var _ = Describe("SonarQubeProject Controller", func() {
 		Expect(mock.renameMainBranchCalls).To(Equal(0))
 	})
 
+	It("continue la réconciliation si GetProjectMainBranch échoue", func() {
+		instanceName := "proj-instance-branch-err"
+		projectName := "proj-branch-err"
+		nn := types.NamespacedName{Name: projectName, Namespace: "default"}
+		defer deleteProject(projectName)
+		defer deleteInstanceIfExists(instanceName)
+
+		newReadyInstance(ctx, instanceName)
+		p := newTestProject(projectName, instanceName, "proj-branch-err-key")
+		p.Spec.MainBranch = "develop"
+		Expect(k8sClient.Create(ctx, p)).To(Succeed())
+
+		mock := &mockSonarClient{
+			getProjectResult:        &sonarqube.Project{Key: "proj-branch-err-key", Visibility: "private"},
+			getProjectMainBranchErr: fmt.Errorf("API unavailable"),
+		}
+		_, err := newProjectReconciler(mock).Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Le rename ne doit pas avoir été tenté
+		Expect(mock.renameMainBranchCalls).To(Equal(0))
+
+		// Le projet doit quand même être Ready
+		updated := &sonarqubev1alpha1.SonarQubeProject{}
+		Expect(k8sClient.Get(ctx, nn, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal("Ready"))
+	})
+
 	It("supprime le projet SonarQube à la suppression de la ressource", func() {
 		instanceName := "proj-instance-delete"
 		projectName := "proj-delete"

--- a/internal/sonarqube/client.go
+++ b/internal/sonarqube/client.go
@@ -108,6 +108,10 @@ type Client interface {
 	GetProject(ctx context.Context, key string) (*Project, error)
 	DeleteProject(ctx context.Context, key string) error
 	UpdateProjectVisibility(ctx context.Context, key, visibility string) error
+	// GetProjectMainBranch returns the name of the main branch of the project.
+	GetProjectMainBranch(ctx context.Context, projectKey string) (string, error)
+	// RenameMainBranch renames the main branch of the project.
+	RenameMainBranch(ctx context.Context, projectKey, branchName string) error
 
 	// Quality Gates
 	ListQualityGates(ctx context.Context) ([]QualityGate, error)
@@ -414,6 +418,38 @@ func (c *httpClient) UpdateProjectVisibility(ctx context.Context, key, visibilit
 	_, err := c.do(ctx, http.MethodPost, "/api/projects/update_visibility", url.Values{
 		"project":    {key},
 		"visibility": {visibility},
+	})
+	return err
+}
+
+type projectBranchesResponse struct {
+	Branches []struct {
+		Name   string `json:"name"`
+		IsMain bool   `json:"isMain"`
+	} `json:"branches"`
+}
+
+func (c *httpClient) GetProjectMainBranch(ctx context.Context, projectKey string) (string, error) {
+	body, err := c.do(ctx, http.MethodGet, "/api/project_branches/list", url.Values{"project": {projectKey}})
+	if err != nil {
+		return "", err
+	}
+	var result projectBranchesResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", err
+	}
+	for _, b := range result.Branches {
+		if b.IsMain {
+			return b.Name, nil
+		}
+	}
+	return "", fmt.Errorf("project %q: no main branch found", projectKey)
+}
+
+func (c *httpClient) RenameMainBranch(ctx context.Context, projectKey, branchName string) error {
+	_, err := c.do(ctx, http.MethodPost, "/api/project_branches/rename", url.Values{
+		"project": {projectKey},
+		"name":    {branchName},
 	})
 	return err
 }

--- a/internal/sonarqube/client_test.go
+++ b/internal/sonarqube/client_test.go
@@ -309,8 +309,10 @@ func TestDeactivateUser(t *testing.T) {
 }
 
 func TestGetProjectMainBranch(t *testing.T) {
+	var gotProject string
 	client := newTestServer(t, map[string]http.HandlerFunc{
-		"/api/project_branches/list": func(w http.ResponseWriter, _ *http.Request) {
+		"/api/project_branches/list": func(w http.ResponseWriter, r *http.Request) {
+			gotProject = r.URL.Query().Get("project")
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"branches":[{"name":"develop","isMain":true},{"name":"feature/x","isMain":false}]}`))
 		},
@@ -319,6 +321,7 @@ func TestGetProjectMainBranch(t *testing.T) {
 	branch, err := client.GetProjectMainBranch(context.Background(), "my-project")
 	require.NoError(t, err)
 	assert.Equal(t, "develop", branch)
+	assert.Equal(t, "my-project", gotProject)
 }
 
 func TestGetProjectMainBranch_NoMain(t *testing.T) {

--- a/internal/sonarqube/client_test.go
+++ b/internal/sonarqube/client_test.go
@@ -308,6 +308,48 @@ func TestDeactivateUser(t *testing.T) {
 	assert.Equal(t, "john.doe", gotLogin)
 }
 
+func TestGetProjectMainBranch(t *testing.T) {
+	client := newTestServer(t, map[string]http.HandlerFunc{
+		"/api/project_branches/list": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"branches":[{"name":"develop","isMain":true},{"name":"feature/x","isMain":false}]}`))
+		},
+	})
+
+	branch, err := client.GetProjectMainBranch(context.Background(), "my-project")
+	require.NoError(t, err)
+	assert.Equal(t, "develop", branch)
+}
+
+func TestGetProjectMainBranch_NoMain(t *testing.T) {
+	client := newTestServer(t, map[string]http.HandlerFunc{
+		"/api/project_branches/list": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"branches":[]}`))
+		},
+	})
+
+	_, err := client.GetProjectMainBranch(context.Background(), "my-project")
+	require.Error(t, err)
+}
+
+func TestRenameMainBranch(t *testing.T) {
+	var gotProject, gotName string
+	client := newTestServer(t, map[string]http.HandlerFunc{
+		"/api/project_branches/rename": func(w http.ResponseWriter, r *http.Request) {
+			_ = r.ParseForm()
+			gotProject = r.FormValue("project")
+			gotName = r.FormValue("name")
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+
+	err := client.RenameMainBranch(context.Background(), "my-project", "develop")
+	require.NoError(t, err)
+	assert.Equal(t, "my-project", gotProject)
+	assert.Equal(t, "develop", gotName)
+}
+
 func TestBearerTokenSent(t *testing.T) {
 	var receivedAuth string
 	client := newTestServer(t, map[string]http.HandlerFunc{


### PR DESCRIPTION
## Summary

- `spec.mainBranch` était déclaré dans le CRD et stocké dans etcd mais jamais appliqué à SonarQube — le projet était créé avec la branche par défaut de SonarQube (`main`) peu importe ce qui était déclaré
- Ajout de `GetProjectMainBranch` (`GET /api/project_branches/list`) et `RenameMainBranch` (`POST /api/project_branches/rename`) dans le client SonarQube
- Réconciliation dans `reconcileProject` : fetch la branche courante, renomme uniquement si elle diffère du spec (drift detection)
- Erreurs non-fatales : warning event émis, réconciliation continue sans bloquer le projet en `Failed`

## Test plan

- [ ] Tests client HTTP : `TestGetProjectMainBranch`, `TestGetProjectMainBranch_NoMain`, `TestRenameMainBranch`
- [ ] Tests contrôleur : renomme quand la branche diffère du spec, no-op quand identique
- [ ] Tester localement avec `spec.mainBranch: develop` sur le gitops example