### PR TITLE
fix(plugin): acknowledge marketplace risk consent on first install

### DIFF
--- a/docs/reference/sonarqube-api.md
+++ b/docs/reference/sonarqube-api.md
@@ -63,19 +63,20 @@ The operator uses `gateName` everywhere.
 `conditionID` parameter for `delete_condition` is therefore a string —
 already correct in the client.
 
-### Plugin install requires `risk_consent`
+### Plugin install requires `acknowledge_risk_consent`
 
 SonarQube 10.x requires admin consent for marketplace plugins before
 any plugin install will succeed:
 
 ```
-POST /api/plugins/risk_consent
+POST /api/plugins/acknowledge_risk_consent
 ```
 
-Without this call, `POST /api/plugins/install` returns an error even
-with a valid admin token. **This is currently not handled by the
-operator** — see the open item under
-[Phase 8.5 in the roadmap](https://github.com/BEIRDINH0S/sonarqube-operator/blob/main/ROADMAP.md).
+Without this call, `POST /api/plugins/install` returns
+`Can't install plugin without accepting firstly plugins risk consent`
+even with a valid admin token. The plugin controller detects this
+specific error, calls the consent endpoint, and retries the install
+once — declaring a `SonarQubePlugin` CR is itself the explicit opt-in.
 
 ---
 

--- a/internal/controller/sonarqubeinstance_controller_test.go
+++ b/internal/controller/sonarqubeinstance_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -49,6 +50,11 @@ type mockSonarClient struct {
 	lastInstalledKey     string
 	lastInstalledVersion string
 	uninstallPluginCalls int
+	// install retry on risk-consent: nth attempt (1-indexed) returns the consent error,
+	// subsequent attempts return nil. 0 disables the simulation.
+	installPluginConsentErrUntilAttempt int
+	acknowledgeRiskConsentCalls         int
+	acknowledgeRiskConsentErr           error
 	// project
 	getProjectResult           *sonarqube.Project
 	getProjectErr              error
@@ -105,11 +111,18 @@ func (m *mockSonarClient) InstallPlugin(_ context.Context, key, version string) 
 	m.installPluginCalls++
 	m.lastInstalledKey = key
 	m.lastInstalledVersion = version
+	if m.installPluginCalls <= m.installPluginConsentErrUntilAttempt {
+		return errors.New("Can't install plugin without accepting firstly plugins risk consent")
+	}
 	return nil
 }
 func (m *mockSonarClient) UninstallPlugin(_ context.Context, _ string) error {
 	m.uninstallPluginCalls++
 	return nil
+}
+func (m *mockSonarClient) AcknowledgeRiskConsent(_ context.Context) error {
+	m.acknowledgeRiskConsentCalls++
+	return m.acknowledgeRiskConsentErr
 }
 func (m *mockSonarClient) CreateProject(_ context.Context, _, _, _ string) error {
 	m.createProjectCalls++

--- a/internal/controller/sonarqubeplugin_controller.go
+++ b/internal/controller/sonarqubeplugin_controller.go
@@ -222,7 +222,20 @@ func (r *SonarQubePluginReconciler) installPlugin(ctx context.Context, plugin *s
 	})
 	_ = r.Status().Update(ctx, plugin)
 
-	if err := sonarClient.InstallPlugin(ctx, plugin.Spec.Key, plugin.Spec.Version); err != nil {
+	err := sonarClient.InstallPlugin(ctx, plugin.Spec.Key, plugin.Spec.Version)
+	if err != nil && sonarqube.IsRiskConsentRequired(err) {
+		// SonarQube 10.x refuses plugin installs until the marketplace risk consent
+		// is acknowledged. Declaring a SonarQubePlugin CR is itself the explicit
+		// opt-in, so acknowledge transparently and retry once.
+		if ackErr := sonarClient.AcknowledgeRiskConsent(ctx); ackErr != nil {
+			err = fmt.Errorf("acknowledging plugin risk consent: %w", ackErr)
+		} else {
+			r.Recorder.Event(plugin, corev1.EventTypeNormal, "RiskConsentAccepted",
+				"Acknowledged SonarQube marketplace plugins risk consent")
+			err = sonarClient.InstallPlugin(ctx, plugin.Spec.Key, plugin.Spec.Version)
+		}
+	}
+	if err != nil {
 		plugin.Status.Phase = phaseFailed
 		apimeta.SetStatusCondition(&plugin.Status.Conditions, metav1.Condition{
 			Type:               conditionInstalled,

--- a/internal/controller/sonarqubeplugin_controller_test.go
+++ b/internal/controller/sonarqubeplugin_controller_test.go
@@ -174,6 +174,33 @@ var _ = Describe("SonarQubePlugin Controller", func() {
 		Expect(updated.Status.RestartRequired).To(BeFalse())
 	})
 
+	It("acquitte le risk consent et réessaie l'install si SonarQube le refuse", func() {
+		instanceName := "instance-consent"
+		pluginName := "plugin-consent"
+		nn := types.NamespacedName{Name: pluginName, Namespace: "default"}
+		defer deletePlugin(pluginName)
+		defer deleteInstance(instanceName)
+
+		newReadyInstance(ctx, instanceName)
+		Expect(k8sClient.Create(ctx, newTestPlugin(pluginName, instanceName, "7.30.1"))).To(Succeed())
+
+		// 1er appel à InstallPlugin → erreur "risk consent"
+		// AcknowledgeRiskConsent → ok
+		// 2e appel à InstallPlugin → ok
+		mock := &mockSonarClient{
+			installPluginConsentErrUntilAttempt: 1,
+		}
+		_, err := newPluginReconciler(mock).Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(mock.acknowledgeRiskConsentCalls).To(Equal(1))
+		Expect(mock.installPluginCalls).To(Equal(2))
+
+		updated := &sonarqubev1alpha1.SonarQubePlugin{}
+		Expect(k8sClient.Get(ctx, nn, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal("Installed"))
+	})
+
 	It("réinstalle si la version est mauvaise", func() {
 		instanceName := "instance-upgrade"
 		pluginName := "plugin-upgrade"

--- a/internal/sonarqube/client.go
+++ b/internal/sonarqube/client.go
@@ -102,6 +102,9 @@ type Client interface {
 	ListInstalledPlugins(ctx context.Context) ([]Plugin, error)
 	InstallPlugin(ctx context.Context, key, version string) error
 	UninstallPlugin(ctx context.Context, key string) error
+	// AcknowledgeRiskConsent accepts the marketplace plugins risk consent.
+	// Required once on SonarQube 10.x before any /api/plugins/install call succeeds.
+	AcknowledgeRiskConsent(ctx context.Context) error
 
 	// Projets
 	CreateProject(ctx context.Context, key, name, visibility string) error
@@ -374,6 +377,21 @@ func (c *httpClient) InstallPlugin(ctx context.Context, key, version string) err
 func (c *httpClient) UninstallPlugin(ctx context.Context, key string) error {
 	_, err := c.do(ctx, http.MethodPost, "/api/plugins/uninstall", url.Values{"key": {key}})
 	return err
+}
+
+func (c *httpClient) AcknowledgeRiskConsent(ctx context.Context) error {
+	_, err := c.do(ctx, http.MethodPost, "/api/plugins/acknowledge_risk_consent", url.Values{})
+	return err
+}
+
+// IsRiskConsentRequired returns true when SonarQube refused a plugin install because
+// the marketplace risk consent has not been acknowledged yet. The error message comes
+// from SonarQube as a JSON body, so we match on its text rather than on a status code.
+func IsRiskConsentRequired(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "risk consent")
 }
 
 // --- Projets ---

--- a/internal/sonarqube/client_test.go
+++ b/internal/sonarqube/client_test.go
@@ -118,6 +118,39 @@ func TestUninstallPlugin(t *testing.T) {
 	assert.Equal(t, "sonar-java", receivedKey)
 }
 
+func TestAcknowledgeRiskConsent(t *testing.T) {
+	var called int
+	client := newTestServer(t, map[string]http.HandlerFunc{
+		"/api/plugins/acknowledge_risk_consent": func(w http.ResponseWriter, r *http.Request) {
+			called++
+			assert.Equal(t, http.MethodPost, r.Method)
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+
+	err := client.AcknowledgeRiskConsent(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, called)
+}
+
+func TestIsRiskConsentRequired(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("HTTP 500: boom"), false},
+		{"sonarqube message", errors.New("Can't install plugin without accepting firstly plugins risk consent"), true},
+		{"case-insensitive", errors.New("Risk Consent missing"), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sonarqube.IsRiskConsentRequired(tc.err))
+		})
+	}
+}
+
 func TestCreateProject(t *testing.T) {
 	var receivedKey, receivedName, receivedVisibility string
 	client := newTestServer(t, map[string]http.HandlerFunc{


### PR DESCRIPTION
## Summary
- SonarQube 10.x rejects `POST /api/plugins/install` with `Can't install plugin without accepting firstly plugins risk consent` until the marketplace risk consent is acknowledged once on the instance.
- The plugin controller did not handle this and looped in exponential backoff forever (observed in cluster: `SonarQubePlugin/scmgit` stuck in `phase=Installing`, controller log spamming `InstallFailed`).
- Detect that specific error, call `POST /api/plugins/acknowledge_risk_consent`, retry the install once. Declaring a `SonarQubePlugin` CR is itself the explicit opt-in, so no new Spec field is needed.

## Changes
- `internal/sonarqube/client`: add `AcknowledgeRiskConsent(ctx)` to the `Client` interface + `httpClient`, and an `IsRiskConsentRequired(err)` helper that matches on the SonarQube error message.
- `internal/controller/sonarqubeplugin`: on `InstallPlugin` failure that matches the consent pattern, call `AcknowledgeRiskConsent` then retry `InstallPlugin` once. A Normal event `RiskConsentAccepted` is emitted so the user sees it in `kubectl describe`.
- `internal/controller/sonarqubeinstance_controller_test.go`: extend the shared `mockSonarClient` with `AcknowledgeRiskConsent` + a knob (`installPluginConsentErrUntilAttempt`) to simulate SonarQube refusing the first N installs with the consent error.
- `docs/reference/sonarqube-api.md`: fix the endpoint name (was `risk_consent`, actual is `acknowledge_risk_consent`) and remove the "not handled by the operator" disclaimer.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/sonarqube/... -count=1` — passes (incl. new `TestAcknowledgeRiskConsent` and `TestIsRiskConsentRequired`).
- [x] `go test ./internal/controller/... -count=1` — 68/68 specs pass on Windows envtest (`AfterSuite` teardown shows the known Windows process-signal limitation, unrelated to this change).
- [ ] After merge, redeploy the operator and confirm `SonarQubePlugin/scmgit` reaches `phase=Installed`.