### PR TITLE
fix(plugin): use settings/set for risk consent on all SonarQube 10.x

### DIFF
--- a/docs/reference/sonarqube-api.md
+++ b/docs/reference/sonarqube-api.md
@@ -63,20 +63,27 @@ The operator uses `gateName` everywhere.
 `conditionID` parameter for `delete_condition` is therefore a string —
 already correct in the client.
 
-### Plugin install requires `acknowledge_risk_consent`
+### Plugin install requires the risk-consent system property
 
 SonarQube 10.x requires admin consent for marketplace plugins before
-any plugin install will succeed:
+any plugin install will succeed. The consent state lives in the
+`sonar.plugins.risk.consent` system property (default `NOT_ACCEPTED`).
+
+A dedicated `POST /api/plugins/acknowledge_risk_consent` action exists
+in some 10.x patch releases but is missing on others (e.g. 10.3.0
+returns `Unknown url`). The reliable cross-version way to flip it is:
 
 ```
-POST /api/plugins/acknowledge_risk_consent
+POST /api/settings/set
+  key=sonar.plugins.risk.consent
+  value=ACCEPTED
 ```
 
-Without this call, `POST /api/plugins/install` returns
+Without this, `POST /api/plugins/install` returns
 `Can't install plugin without accepting firstly plugins risk consent`
 even with a valid admin token. The plugin controller detects this
-specific error, calls the consent endpoint, and retries the install
-once — declaring a `SonarQubePlugin` CR is itself the explicit opt-in.
+error, sets the property, and retries the install once — declaring a
+`SonarQubePlugin` CR is itself the explicit opt-in.
 
 ---
 

--- a/internal/sonarqube/client.go
+++ b/internal/sonarqube/client.go
@@ -380,7 +380,14 @@ func (c *httpClient) UninstallPlugin(ctx context.Context, key string) error {
 }
 
 func (c *httpClient) AcknowledgeRiskConsent(ctx context.Context) error {
-	_, err := c.do(ctx, http.MethodPost, "/api/plugins/acknowledge_risk_consent", url.Values{})
+	// SonarQube 10.x stores the marketplace risk consent as a system property.
+	// The dedicated /api/plugins/acknowledge_risk_consent action does not exist
+	// on every 10.x patch level (e.g. 10.3.0 returns "Unknown url"), but setting
+	// the property via /api/settings/set works on all of them.
+	_, err := c.do(ctx, http.MethodPost, "/api/settings/set", url.Values{
+		"key":   {"sonar.plugins.risk.consent"},
+		"value": {"ACCEPTED"},
+	})
 	return err
 }
 

--- a/internal/sonarqube/client_test.go
+++ b/internal/sonarqube/client_test.go
@@ -119,18 +119,23 @@ func TestUninstallPlugin(t *testing.T) {
 }
 
 func TestAcknowledgeRiskConsent(t *testing.T) {
-	var called int
+	var calls int
+	var receivedKey, receivedValue string
 	client := newTestServer(t, map[string]http.HandlerFunc{
-		"/api/plugins/acknowledge_risk_consent": func(w http.ResponseWriter, r *http.Request) {
-			called++
-			assert.Equal(t, http.MethodPost, r.Method)
+		"/api/settings/set": func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			require.NoError(t, r.ParseForm())
+			receivedKey = r.FormValue("key")
+			receivedValue = r.FormValue("value")
 			w.WriteHeader(http.StatusNoContent)
 		},
 	})
 
 	err := client.AcknowledgeRiskConsent(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, 1, called)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "sonar.plugins.risk.consent", receivedKey)
+	assert.Equal(t, "ACCEPTED", receivedValue)
 }
 
 func TestIsRiskConsentRequired(t *testing.T) {


### PR DESCRIPTION
## Summary
Follow-up to #6. The dedicated `POST /api/plugins/acknowledge_risk_consent` action does not exist on every SonarQube 10.x patch level — verified on `10.3.0.82913` where it returns `Unknown url : /api/plugins/acknowledge_risk_consent`. The operator was therefore hitting the new consent path correctly but failing at the ack step.

The consent state is actually a system property (`sonar.plugins.risk.consent`, default `NOT_ACCEPTED`). Setting it to `ACCEPTED` via `POST /api/settings/set` works on all 10.x versions, including 10.3.

## Changes
- `internal/sonarqube/client.AcknowledgeRiskConsent`: switch endpoint to `POST /api/settings/set` with `key=sonar.plugins.risk.consent&value=ACCEPTED`.
- `internal/sonarqube/client_test.TestAcknowledgeRiskConsent`: assert the form fields in the request body.
- `docs/reference/sonarqube-api.md`: explain that `acknowledge_risk_consent` is missing on some 10.x patch levels and document the property-based approach.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/sonarqube/... -count=1` — passes.
- [x] End-to-end on kind (SonarQube 10.3.0.82913): rebuilt operator, restarted deployment, `sonar.plugins.risk.consent` flipped from `NOT_ACCEPTED` to `ACCEPTED` on first reconcile after a `SonarQubePlugin` install was refused. Event `RiskConsentAccepted` emitted on the CR. Subsequent `InstallPlugin` call no longer hits the consent error.

## Note
Independent of this PR, the bundled `SonarQubePlugin/scmgit` from the GitOps example fails on 10.3 with `No plugin with key 'scmgit' or plugin 'scmgit' is already installed in latest version` — Git SCM is bundled into core in SonarQube 10.3 (not exposed in `/api/plugins/available`). Not a regression here; that CR needs to go.