### PR TITLE
fix(plugin): release finalizer when plugin is not installed in SonarQube

### DIFF
--- a/internal/controller/sonarqubeplugin_controller.go
+++ b/internal/controller/sonarqubeplugin_controller.go
@@ -281,20 +281,40 @@ func (r *SonarQubePluginReconciler) signalInstanceRestart(ctx context.Context, p
 }
 
 // handleDeletion désinstalle le plugin avant de retirer le finalizer.
+// Si le plugin n'est pas (ou plus) installé côté SonarQube, on saute l'appel
+// uninstall : sinon une CR qui n'a jamais réussi son install (clé invalide,
+// plugin bundled dans le core, etc.) reste bloquée pour toujours par le
+// finalizer.
 func (r *SonarQubePluginReconciler) handleDeletion(ctx context.Context, plugin *sonarqubev1alpha1.SonarQubePlugin, sonarClient sonarqube.Client, instance *sonarqubev1alpha1.SonarQubeInstance) error {
 	if !controllerutil.ContainsFinalizer(plugin, pluginFinalizer) {
 		return nil
 	}
 
-	if err := sonarClient.UninstallPlugin(ctx, plugin.Spec.Key); err != nil {
-		r.Recorder.Event(plugin, corev1.EventTypeWarning, "UninstallFailed", err.Error())
-		return fmt.Errorf("uninstalling plugin on deletion: %w", err)
+	installed, err := sonarClient.ListInstalledPlugins(ctx)
+	if err != nil {
+		return fmt.Errorf("listing plugins on deletion: %w", err)
 	}
 
-	r.signalInstanceRestart(ctx, plugin, instance)
+	isInstalled := false
+	for i := range installed {
+		if installed[i].Key == plugin.Spec.Key {
+			isInstalled = true
+			break
+		}
+	}
 
-	r.Recorder.Event(plugin, corev1.EventTypeNormal, "Uninstalled",
-		fmt.Sprintf("Plugin %q uninstalled", plugin.Spec.Key))
+	if isInstalled {
+		if err := sonarClient.UninstallPlugin(ctx, plugin.Spec.Key); err != nil {
+			r.Recorder.Event(plugin, corev1.EventTypeWarning, "UninstallFailed", err.Error())
+			return fmt.Errorf("uninstalling plugin on deletion: %w", err)
+		}
+		r.signalInstanceRestart(ctx, plugin, instance)
+		r.Recorder.Event(plugin, corev1.EventTypeNormal, "Uninstalled",
+			fmt.Sprintf("Plugin %q uninstalled", plugin.Spec.Key))
+	} else {
+		r.Recorder.Event(plugin, corev1.EventTypeNormal, "AlreadyUninstalled",
+			fmt.Sprintf("Plugin %q is not installed in SonarQube — releasing finalizer", plugin.Spec.Key))
+	}
 
 	controllerutil.RemoveFinalizer(plugin, pluginFinalizer)
 	return r.Update(ctx, plugin)

--- a/internal/controller/sonarqubeplugin_controller_test.go
+++ b/internal/controller/sonarqubeplugin_controller_test.go
@@ -201,6 +201,61 @@ var _ = Describe("SonarQubePlugin Controller", func() {
 		Expect(updated.Status.Phase).To(Equal("Installed"))
 	})
 
+	It("retire le finalizer sans appeler UninstallPlugin si le plugin n'est pas installé", func() {
+		instanceName := "instance-del-missing"
+		pluginName := "plugin-del-missing"
+		nn := types.NamespacedName{Name: pluginName, Namespace: "default"}
+		defer deletePlugin(pluginName)
+		defer deleteInstance(instanceName)
+
+		newReadyInstance(ctx, instanceName)
+		Expect(k8sClient.Create(ctx, newTestPlugin(pluginName, instanceName, "7.30.1"))).To(Succeed())
+
+		// 1er reconcile : pose le finalizer + install
+		mock := &mockSonarClient{}
+		_, err := newPluginReconciler(mock).Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		// SonarQube ne connaît pas le plugin (clé invalide / bundled core).
+		// La CR est supprimée → finalizer doit lâcher sans appel à uninstall.
+		mock.installedPlugins = nil
+		Expect(k8sClient.Delete(ctx, newTestPlugin(pluginName, instanceName, "7.30.1"))).To(Succeed())
+
+		_, err = newPluginReconciler(mock).Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(mock.uninstallPluginCalls).To(Equal(0))
+
+		// La CR doit avoir disparu (finalizer retiré → suppression effective).
+		gone := &sonarqubev1alpha1.SonarQubePlugin{}
+		Expect(k8sClient.Get(ctx, nn, gone)).NotTo(Succeed())
+	})
+
+	It("appelle UninstallPlugin quand le plugin est bien installé côté SonarQube", func() {
+		instanceName := "instance-del-present"
+		pluginName := "plugin-del-present"
+		nn := types.NamespacedName{Name: pluginName, Namespace: "default"}
+		defer deletePlugin(pluginName)
+		defer deleteInstance(instanceName)
+
+		newReadyInstance(ctx, instanceName)
+		Expect(k8sClient.Create(ctx, newTestPlugin(pluginName, instanceName, "7.30.1"))).To(Succeed())
+
+		// 1er reconcile : pose le finalizer + install
+		mock := &mockSonarClient{}
+		_, err := newPluginReconciler(mock).Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Le plugin est listé comme installé → la suppression doit l'appeler.
+		mock.installedPlugins = []sonarqube.Plugin{{Key: "sonar-java", Version: "7.30.1"}}
+		Expect(k8sClient.Delete(ctx, newTestPlugin(pluginName, instanceName, "7.30.1"))).To(Succeed())
+
+		_, err = newPluginReconciler(mock).Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(mock.uninstallPluginCalls).To(Equal(1))
+	})
+
 	It("réinstalle si la version est mauvaise", func() {
 		instanceName := "instance-upgrade"
 		pluginName := "plugin-upgrade"


### PR DESCRIPTION
## Summary
A `SonarQubePlugin` CR whose install never succeeded — invalid key, plugin bundled into SonarQube core, marketplace mismatch, etc. — used to be stuck forever on deletion: `handleDeletion` called `UninstallPlugin` unconditionally, SonarQube returned `400` (plugin wasn't installed), the controller treated that as a hard error, and the finalizer was never removed.

Real-world repro from this session: a `SonarQubePlugin` CR with `spec.key=scmgit` against SonarQube 10.3 — Git SCM is bundled into the core in 10.x and not exposed via `/api/plugins/available`, so neither install nor uninstall ever succeeds.

## Changes
- `internal/controller/sonarqubeplugin_controller.handleDeletion`: list installed plugins first, only call `UninstallPlugin` when the key is actually present. Otherwise emit a Normal `AlreadyUninstalled` event and release the finalizer so the CR is garbage-collected. The instance restart is also skipped on this branch since nothing on the SonarQube side actually changed.
- Two new specs in `sonarqubeplugin_controller_test.go`:
  - finalizer is released without calling `UninstallPlugin` when the plugin is absent from `ListInstalledPlugins`
  - `UninstallPlugin` is still called when the plugin is present (existing behavior preserved)

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/controller/... -count=1` — 70/70 specs pass on Windows envtest (the `AfterSuite` failure is the known Windows process-signal teardown limitation, unrelated to this change).
- [x] Manually reproduced the stuck-finalizer behavior on the kind cluster (`SonarQubePlugin/scmgit`, deletionTimestamp set, finalizer never removed). Once this PR is rebuilt, the same scenario should let the CR delete cleanly.