### PR TITLE
chore: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Something the operator does is wrong, broken, or unexpected.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in as much of
+        the form as you can — the operator logs and the CR YAML are usually what
+        we need first.
+  - type: input
+    id: operator-version
+    attributes:
+      label: Operator version
+      description: e.g. v0.5.0, or a commit SHA from main
+      placeholder: v0.5.0
+    validations:
+      required: true
+  - type: input
+    id: sonarqube-version
+    attributes:
+      label: SonarQube version
+      description: From `kubectl get sonarqubeinstance -o jsonpath='{.items[0].status.version}'`
+      placeholder: 10.3.0.82913
+    validations:
+      required: true
+  - type: input
+    id: kubernetes
+    attributes:
+      label: Kubernetes flavor and version
+      description: e.g. kind 0.31.0 / k8s 1.31, EKS 1.30, GKE Autopilot 1.31
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - Helm chart (OCI)
+        - install.yaml (kubectl apply)
+        - kustomize from source
+        - Other / custom
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: Describe the actual behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: what-expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Reproducer
+      description: |
+        The CR YAML and the kubectl commands that reproduce the problem.
+        Use the smallest minimal CR that still triggers it.
+      render: yaml
+    validations:
+      required: true
+  - type: textarea
+    id: operator-logs
+    attributes:
+      label: Operator logs
+      description: |
+        `kubectl logs -n sonarqube-operator-system deploy/sonarqube-operator --tail=200`
+        (Trim or scrub anything sensitive — secrets, tokens, internal hostnames.)
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: cr-status
+    attributes:
+      label: CR status
+      description: |
+        `kubectl get <kind> <name> -n <ns> -o yaml` — the `.status` section is what we need.
+      render: yaml

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/BEIRDINH0S/sonarqube-operator/discussions
+    about: Use GitHub Discussions for questions about how to use the operator.
+  - name: Security report
+    url: https://github.com/BEIRDINH0S/sonarqube-operator/security/advisories/new
+    about: Report a security vulnerability privately via a GitHub security advisory.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Propose a new field, CRD, behavior, or integration.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Concrete use cases beat abstract wishes. Tell us what you are trying to
+        accomplish, not just what you want the operator to do.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do? What blocks you today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API or behavior
+      description: |
+        If you have a concrete idea, sketch it. CRD field shapes, new endpoints,
+        new CRDs, etc. It's fine to leave this open if you don't.
+      render: yaml
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about, with their tradeoffs.
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to send a PR for this.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- 1-3 bullets: why this PR exists, in plain language. -->
+-
+
+## Changes
+
+<!-- What was edited and why. Per-area or per-file is fine. Keep it terse. -->
+-
+
+## Test plan
+
+<!-- Check what you actually ran. Add cluster steps when relevant. -->
+- [ ] `go build ./...`
+- [ ] `go vet ./...`
+- [ ] `go test ./... -count=1`
+- [ ]
+
+## Related issues
+
+<!-- Use `Closes #N` to auto-close the matching issue on merge. -->
+Closes #
+
+## Notes for the reviewer
+
+<!-- Optional: risk areas, follow-ups deliberately left out, anything you want flagged. -->


### PR DESCRIPTION
## Summary
- Adds GitHub Issue Forms (`bug_report`, `feature_request`) and a `config.yml` that disables blank issues and points questions to Discussions / security to private advisories.
- Adds a single `pull_request_template.md` matching the Summary / Changes / Test plan / Closes shape used in PRs #1–#8.

## Changes
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured fields for operator + SonarQube versions, Kubernetes flavor, install method, reproducer, logs, CR status.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem / use case, proposed API, alternatives.
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false` plus contact links.
- `.github/pull_request_template.md` — applied to every new PR by default.

## Test plan
- [x] YAML files validate (GitHub will surface a chooser at /issues/new).
- [ ] After merge, open a test issue and a test PR to confirm both pickers render correctly.

## Related issues
Closes #25