### PR TITLE
feat(qualitygate): typed onNewCode flag on conditions

### DIFF
--- a/api/v1alpha1/sonarqubequalitygate_types.go
+++ b/api/v1alpha1/sonarqubequalitygate_types.go
@@ -42,6 +42,7 @@ type SonarQubeQualityGateSpec struct {
 }
 
 // QualityGateConditionSpec définit une règle du quality gate.
+// +kubebuilder:validation:XValidation:rule="!self.onNewCode || self.metric.startsWith('new_')",message="when onNewCode is true, metric must be a new_* metric"
 type QualityGateConditionSpec struct {
 	// metric est la métrique SonarQube à évaluer (ex: coverage, duplicated_lines_density).
 	// +kubebuilder:validation:MinLength=1
@@ -54,6 +55,13 @@ type QualityGateConditionSpec struct {
 	// value est le seuil d'alerte (ex: "80" pour 80% de couverture minimum avec LT).
 	// +kubebuilder:validation:MinLength=1
 	Value string `json:"value"`
+
+	// onNewCode marks this condition as targeting the new code period.
+	// Only metrics whose key starts with "new_" can be set on the new code period
+	// — the API server rejects the CR otherwise.
+	// +optional
+	// +kubebuilder:default=false
+	OnNewCode bool `json:"onNewCode,omitempty"`
 }
 
 // SonarQubeQualityGateStatus defines the observed state of SonarQubeQualityGate.

--- a/config/crd/bases/sonarqube.sonarqube.io_sonarqubequalitygates.yaml
+++ b/config/crd/bases/sonarqube.sonarqube.io_sonarqubequalitygates.yaml
@@ -67,6 +67,13 @@ spec:
                         coverage, duplicated_lines_density).'
                       minLength: 1
                       type: string
+                    onNewCode:
+                      default: false
+                      description: |-
+                        onNewCode marks this condition as targeting the new code period.
+                        Only metrics whose key starts with "new_" can be set on the new code period
+                        — the API server rejects the CR otherwise.
+                      type: boolean
                     operator:
                       description: operator est l'opérateur de comparaison.
                       enum:
@@ -83,6 +90,9 @@ spec:
                   - operator
                   - value
                   type: object
+                  x-kubernetes-validations:
+                  - message: when onNewCode is true, metric must be a new_* metric
+                    rule: '!self.onNewCode || self.metric.startsWith(''new_'')'
                 type: array
               instanceRef:
                 description: instanceRef référence la SonarQubeInstance cible.

--- a/internal/controller/sonarqubequalitygate_controller_test.go
+++ b/internal/controller/sonarqubequalitygate_controller_test.go
@@ -307,4 +307,35 @@ var _ = Describe("SonarQubeQualityGate Controller", func() {
 
 		Expect(mock.deleteQualityGateCalls).To(Equal(1))
 	})
+
+	It("rejette une condition onNewCode=true sur une métrique non-new_*", func() {
+		gate := &sonarqubev1alpha1.SonarQubeQualityGate{
+			ObjectMeta: metav1.ObjectMeta{Name: "qg-bad-newcode", Namespace: "default"},
+			Spec: sonarqubev1alpha1.SonarQubeQualityGateSpec{
+				InstanceRef: sonarqubev1alpha1.InstanceRef{Name: "any"},
+				Name:        "qg-bad-newcode",
+				Conditions: []sonarqubev1alpha1.QualityGateConditionSpec{
+					{Metric: "coverage", Operator: "LT", Value: "80", OnNewCode: true},
+				},
+			},
+		}
+		err := k8sClient.Create(ctx, gate)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("metric must be a new_* metric"))
+	})
+
+	It("accepte onNewCode=true quand la métrique commence par new_", func() {
+		gate := &sonarqubev1alpha1.SonarQubeQualityGate{
+			ObjectMeta: metav1.ObjectMeta{Name: "qg-good-newcode", Namespace: "default"},
+			Spec: sonarqubev1alpha1.SonarQubeQualityGateSpec{
+				InstanceRef: sonarqubev1alpha1.InstanceRef{Name: "any"},
+				Name:        "qg-good-newcode",
+				Conditions: []sonarqubev1alpha1.QualityGateConditionSpec{
+					{Metric: "new_coverage", Operator: "LT", Value: "80", OnNewCode: true},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, gate)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, gate)).To(Succeed())
+	})
 })


### PR DESCRIPTION
## Summary
- Adds an explicit `onNewCode` boolean to `QualityGateConditionSpec`.
- Enforces "metric must start with `new_` when `onNewCode: true`" at admission via a CEL `XValidation` rule on the CRD — no webhook deployment needed.
- Reconciler is unchanged: SonarQube already derives the new-code-period target from the metric name itself; the flag is purely declarative intent.

## Changes
- `api/v1alpha1/sonarqubequalitygate_types.go` — new field + CEL rule.
- `config/crd/bases/sonarqube.sonarqube.io_sonarqubequalitygates.yaml` — regenerated.
- `internal/controller/sonarqubequalitygate_controller_test.go` — 2 specs (rejected mismatch, accepted match).

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] `go test ./internal/controller/... -count=1` — 72/72 specs pass on Windows envtest (`AfterSuite` Windows quirk).

## Related issues
Closes #19