### PR TITLE
docs: cover the 5 new CRDs and the instance/project/user enrichments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,25 @@ still ClickOps: quality gates set by hand and lost when the database is
 restored, projects with inconsistent visibility, CI tokens generated once and
 never rotated. This operator fixes all of that.
 
-Five CRDs — `SonarQubeInstance`, `SonarQubePlugin`, `SonarQubeProject`,
-`SonarQubeQualityGate`, `SonarQubeUser` — cover the full surface, with drift
-detection, finalizers, validating webhooks, Prometheus metrics, and
-rate-limited reconciliation. Everything is reconciled continuously: change a
-CR, the operator drives the SonarQube API.
+Ten CRDs cover the full SonarQube surface:
+
+| CRD | Purpose |
+|---|---|
+| `SonarQubeInstance` | StatefulSet + Service + PVC + optional Ingress, with admin bootstrap. |
+| `SonarQubePlugin` | Marketplace plugins, with batched restarts on install/uninstall. |
+| `SonarQubeProject` | Projects with visibility, main branch, quality gate, CI token, tags, links, settings, permissions. |
+| `SonarQubeQualityGate` | Quality gates with conditions, drift-corrected. |
+| `SonarQubeUser` | Users with groups, SCM accounts, standalone tokens, global permissions. |
+| `SonarQubeGroup` | SonarQube groups, drift-corrected. |
+| `SonarQubePermissionTemplate` | Permission templates applied automatically by project-key pattern. |
+| `SonarQubeWebhook` | Project-scoped or global webhooks (HMAC-signed). |
+| `SonarQubeBranchRule` | Per-branch new-code-period, gate override, settings. *(scaffold — admission only)* |
+| `SonarQubeBackup` | Scheduled `pg_dump` + extensions snapshot to PVC or S3. *(scaffold — admission only)* |
+
+All ship with drift detection where applicable, finalizers, validating
+webhooks, Prometheus metrics, and rate-limited reconciliation. Everything
+is reconciled continuously: change a CR, the operator drives the SonarQube
+API.
 
 For a hands-on tour see the
 [GitOps example repo](https://github.com/BEIRDINH0S/sonarqube-operator-gitops-example),

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,9 +5,11 @@ where it is going. For the full per-CRD task list, see the
 [GitHub issues](https://github.com/BEIRDINH0S/sonarqube-operator/issues)
 and the [Releases page](https://github.com/BEIRDINH0S/sonarqube-operator/releases).
 
-> **Current status**: late beta. All five CRDs are implemented and
-> end-to-end tested. The API is in `v1alpha1` and may change before
-> `v1.0.0` — see the changelog for migration notes between releases.
+> **Current status**: late beta. Ten CRDs ship — eight with full
+> reconcile loops, two (`SonarQubeBranchRule`, `SonarQubeBackup`) as
+> admission-only scaffolds. The API is in `v1alpha1` and may change
+> before `v1.0.0` — see the changelog for migration notes between
+> releases.
 
 ---
 
@@ -17,6 +19,19 @@ and the [Releases page](https://github.com/BEIRDINH0S/sonarqube-operator/release
   `SonarQubeProject`, `SonarQubeQualityGate`, `SonarQubeUser`. All
   reconciled with finalizers (non-blocking), drift correction where
   applicable, and full envtest coverage.
+- **Extended CRDs** — `SonarQubeGroup`, `SonarQubePermissionTemplate`,
+  `SonarQubeWebhook` shipped with full reconcile loops; `SonarQubeBranchRule`
+  and `SonarQubeBackup` shipped as admission-only scaffolds (reconcile
+  pipelines tracked as separate follow-ups).
+- **Instance scheduling & security** — `nodeSelector`, `tolerations`,
+  `affinity`, `podSecurityContext`, `securityContext`, ServiceMonitor,
+  DCE topology spec field (single-StatefulSet rendering today; full
+  two-StatefulSet DCE rendering still pending).
+- **Project enrichment** — `tags`, `links`, `settings`, `permissions`
+  with managed-set ownership tracking.
+- **User enrichment** — `scmAccounts`, standalone `tokens` (with
+  `USER_TOKEN` and `GLOBAL_ANALYSIS_TOKEN` types), `globalPermissions`
+  with managed-set ownership tracking.
 - **Production hardening** — leader election, validating webhook
   (opt-in), Prometheus metrics, rate-limited reconcile, batched
   SonarQube restarts on plugin install/uninstall.
@@ -74,11 +89,21 @@ running in production with at least a handful of external users.
 - OpenTelemetry tracing through the Reconcile loop
 - OpenShift-specific testing and SCC packaging
 - Mutation / fuzz / soak testing
-- Additional CRDs:
-  - `SonarQubeGroup` — declarative SonarQube groups
-  - `SonarQubeBranchRule` — per-branch quality gate rules
-  - `SonarQubeWebhook` — manage SonarQube → external webhooks as code
-  - `SonarQubeBackup` — orchestrate `pg_dump` + PVC snapshot
+- **Reconcile pipelines for the scaffold CRDs**:
+  - `SonarQubeBranchRule` — actual calls to `/api/new_code_periods/set`,
+    `/api/qualitygates/select`, `/api/settings/set` scoped to a branch.
+  - `SonarQubeBackup` — materialize a `CronJob` running `pg_dump` +
+    extensions snapshot, ship to PVC/S3, retention pruning.
+- **Instance** — true two-StatefulSet (app + search) DCE rendering
+  driven by `spec.cluster`.
+- **Permission templates** — surface `spec.permissions[]` on
+  `SonarQubePermissionTemplate` so template grants can be declared as
+  code (today they are managed in the SonarQube UI even when the
+  template itself is operator-managed).
+- **Webhook drift correction** — delete + re-create when URL or HMAC
+  secret diverges from the spec.
+- A `SonarQubeRestore` CRD orchestrating the inverse of
+  `SonarQubeBackup`.
 
 These are explicitly **not** blocking for `v1.0.0` and may move forward,
 backward, or get redefined based on user feedback.

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,12 +54,13 @@ continuous. Drift is detected and corrected.
 
     [:octicons-arrow-right-24: Reference](reference/crds/sonarqubeplugin.md)
 
--   :material-folder-multiple:{ .lg .middle } **Projects, gates, users**
+-   :material-folder-multiple:{ .lg .middle } **Projects, gates, users, groups**
 
     ---
 
-    `SonarQubeProject`, `SonarQubeQualityGate`, `SonarQubeUser` — all with
-    drift detection. Configure once in Git, the operator keeps SonarQube in
+    `SonarQubeProject`, `SonarQubeQualityGate`, `SonarQubeUser`,
+    `SonarQubeGroup`, `SonarQubePermissionTemplate` — all with drift
+    detection. Configure once in Git, the operator keeps SonarQube in
     sync.
 
     [:octicons-arrow-right-24: Reference](reference/index.md)
@@ -119,6 +120,8 @@ Then deploy your first instance — see the [Quick Start](getting-started/quick-
 
 ## Project status
 
-Currently in **beta** (`v0.5.x`). All five CRDs are implemented and tested
-end-to-end. APIs are versioned `v1alpha1` and may change before `v1.0.0` — see
-the [changelog](changelog.md) for migration notes.
+Currently in **beta** (`v0.5.x`). Ten CRDs ship — eight with full reconcile
+loops, two (`SonarQubeBranchRule`, `SonarQubeBackup`) shipped as
+admission-only scaffolds with their reconcile pipelines tracked as
+follow-ups. APIs are versioned `v1alpha1` and may change before `v1.0.0`
+— see the [changelog](changelog.md) for migration notes.

--- a/docs/reference/crds/sonarqubebackup.md
+++ b/docs/reference/crds/sonarqubebackup.md
@@ -1,0 +1,264 @@
+# SonarQubeBackup
+
+A scheduled SonarQube backup: a Postgres dump of the SonarQube database
+plus a snapshot of the extensions PVC, taken on a cron schedule and shipped
+to either a PVC or an S3-compatible bucket. Used for disaster recovery and
+for validation before destructive operations (major upgrades, schema
+migrations).
+
+!!! warning "Scaffold — admission only"
+    As of the current release, this CRD ships with full validation
+    (CEL-enforced exclusive choice between `destination.pvc` and
+    `destination.s3`, S3 credentials reference required) but the
+    **reconcile pipeline is not yet implemented**. Applying a
+    `SonarQubeBackup` is accepted by the API server, but no `CronJob` is
+    created and no backups are taken — the resource will sit in
+    `Pending` indefinitely. Tracked as a follow-up in the issue tracker.
+    Use this page as the contract the controller will satisfy once
+    shipped.
+
+| | |
+|---|---|
+| **API group** | `sonarqube.sonarqube.io` |
+| **API version** | `v1alpha1` |
+| **Kind** | `SonarQubeBackup` |
+| **Scope** | Namespaced |
+
+---
+
+## Complete example
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeBackup
+metadata:
+  name: nightly
+  namespace: sonarqube-prod
+spec:
+  # Required. Reference to the SonarQubeInstance to back up.
+  instanceRef:
+    name: sonarqube
+
+  # Required. Standard Kubernetes cron expression.
+  schedule: "0 2 * * *"   # daily at 02:00
+
+  # Optional. Keep the most recent N successful backups. 0 = keep everything.
+  retention: 14
+
+  # Required. Where to ship the backup. Exactly one of pvc / s3 must be set.
+  destination:
+    s3:
+      bucket: sonarqube-backups-prod
+      region: eu-west-3
+      # Optional. Use for MinIO / Ceph / non-AWS S3.
+      endpoint: https://s3.eu-west-3.amazonaws.com
+      credentialsSecretRef:
+        name: s3-backup-creds          # keys: accessKey, secretKey
+```
+
+---
+
+## Spec
+
+### `instanceRef`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Name of the target `SonarQubeInstance`. |
+| `namespace` | string | no | Defaults to the backup's own namespace. |
+
+### `schedule`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | yes |
+| **Min length** | 1 |
+
+Standard cron expression, same syntax as Kubernetes `CronJob.spec.schedule`
+(5 fields: minute, hour, day-of-month, month, day-of-week). Uses the
+controller pod's local timezone (UTC by default in most clusters).
+
+### `retention`
+
+| | |
+|---|---|
+| **Type** | int32 |
+| **Required** | no |
+| **Default** | `0` (keep all) |
+| **Minimum** | `0` |
+
+Number of most-recent **successful** backups to keep. The reconcile
+pipeline (once shipped) prunes older entries on the destination after a
+successful new backup. Failed backups don't count against the retention
+window — they're left in place so an operator can investigate.
+
+`0` keeps every backup forever — combine that with bucket-side lifecycle
+rules for cold-archive policies.
+
+### `destination`
+
+A tagged union: **exactly one** of `pvc` / `s3` must be set. Validated by
+a top-level CEL rule on the spec (`has(self.destination.pvc) || has(self.destination.s3)`)
+and by mutual-exclusion at admission.
+
+#### `destination.pvc`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `claimName` | string | yes | Name of a `PersistentVolumeClaim` in the same namespace as the backup. The PVC must exist; the operator does not create it. |
+| `subPath` | string | no | Optional path inside the PVC. Created if missing. |
+
+Useful when you already have a backup bucket fronted by an in-cluster
+gateway (CSI snapshot landing zone, NFS, etc.) and want to reuse it.
+
+#### `destination.s3`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `bucket` | string | yes | S3 bucket name. The operator does not create the bucket. |
+| `region` | string | no | AWS region. Required for AWS S3; can be omitted for MinIO/Ceph if your endpoint is self-routing. |
+| `endpoint` | string | no | Override the default S3 endpoint. Required for MinIO/Ceph/Wasabi/etc. Format: `https://s3.region.example.com`. |
+| `credentialsSecretRef` | `LocalObjectReference` | yes | Secret in the same namespace with keys `accessKey` and `secretKey`. |
+
+The operator does **not** assume IRSA / Workload Identity / IMDS; pass
+explicit credentials. (IRSA/WI support may be added later if there is
+demand.)
+
+---
+
+## Status
+
+```yaml
+status:
+  phase: Ready
+  cronJobName: sonarqube-backup-nightly
+  lastSuccessfulBackup: "2026-04-26T02:00:42Z"
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: CronJobScheduled
+      message: CronJob sonarqube-backup-nightly schedules backups every day at 02:00
+      lastTransitionTime: "2026-04-26T02:00:42Z"
+```
+
+### `phase`
+
+| Phase | Meaning |
+|---|---|
+| `Pending` | Reconcile pipeline not yet implemented (current state) — or, once implemented, the target instance is not yet `Ready`. |
+| `Ready` | The CronJob has been created and at least one backup has succeeded. (Future) |
+| `Failed` | The most recent backup failed. (Future) |
+
+### Other status fields
+
+| Field | Description |
+|---|---|
+| `cronJobName` | Name of the materialized `CronJob` in the backup's namespace. (Future) |
+| `lastSuccessfulBackup` | Start time of the last successful backup run. (Future) |
+
+---
+
+## Lifecycle (planned)
+
+> The implementation below describes the intended reconcile behavior once
+> the controller is shipped. The current controller is an admission-only
+> scaffold; see the warning at the top of this page.
+
+### Creation
+
+1. The controller materializes a `CronJob` named
+   `<instance>-backup-<backupname>` in the backup's namespace.
+2. Each scheduled run executes a `pg_dump` against the SonarQube database
+   (using credentials read from `instance.spec.database.secretRef`),
+   gzips the result, and uploads it to the destination alongside a
+   manifest describing the SonarQube version, the schema migration ID,
+   and the extensions PVC contents.
+3. After a successful run, the operator updates `lastSuccessfulBackup`
+   and applies the `retention` window to the destination.
+
+### Updates
+
+- Changes to `schedule`, `retention`, or `destination` mutate the
+  underlying CronJob in place.
+- Changes to `instanceRef.name` are rejected at admission (a backup
+  belongs to one instance for life — to retarget, create a new
+  `SonarQubeBackup`).
+
+### Deletion
+
+1. The controller deletes the materialized CronJob (cascaded via owner
+   reference, so technically the deletion is automatic).
+2. **Backup artifacts on the destination are left in place** — the
+   operator never deletes data it didn't create in this reconcile
+   cycle. Clean them up via your bucket lifecycle policy if needed.
+3. Finalizer removed.
+
+---
+
+## Examples
+
+### Daily backup to S3 with 14-day retention
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeBackup
+metadata:
+  name: nightly
+  namespace: sonarqube-prod
+spec:
+  instanceRef:
+    name: sonarqube
+  schedule: "0 2 * * *"
+  retention: 14
+  destination:
+    s3:
+      bucket: sonarqube-backups-prod
+      region: eu-west-3
+      credentialsSecretRef:
+        name: s3-backup-creds
+```
+
+### Hourly backup to a local PVC (development / disaster-recovery drill)
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeBackup
+metadata:
+  name: dev-hourly
+  namespace: sonarqube-dev
+spec:
+  instanceRef:
+    name: sonarqube
+  schedule: "0 * * * *"
+  destination:
+    pvc:
+      claimName: sonarqube-backups
+      subPath: hourly
+```
+
+---
+
+## Restoring from a backup
+
+The operator does **not** ship a one-shot restore command yet. To restore
+manually:
+
+1. Spin down the `SonarQubeInstance` (set `replicas: 0` on the
+   StatefulSet, or delete the instance and recreate the PVCs).
+2. Re-create the SonarQube database from the dump:
+   `psql ... < <dump>.sql`.
+3. Re-mount the extensions PVC contents from the backup manifest.
+4. Bring the instance back up — the operator's bootstrap detects an
+   already-initialized database and skips the admin password reset.
+
+A `SonarQubeRestore` CRD orchestrating this flow is on the roadmap.
+
+---
+
+## See also
+
+- [SonarQubeInstance](sonarqubeinstance.md) — `spec.database` contains
+  the connection details `pg_dump` will use.
+- [Operations → Upgrade](../../operations/upgrade.md) — take a backup
+  before any major version upgrade.

--- a/docs/reference/crds/sonarqubebranchrule.md
+++ b/docs/reference/crds/sonarqubebranchrule.md
@@ -1,0 +1,263 @@
+# SonarQubeBranchRule
+
+Per-branch settings for a SonarQube project: new-code-period mode, optional
+quality-gate override, and per-branch `sonar.*` settings. Most teams need
+this exactly once: long-lived release branches (e.g. `release/1.x`,
+`maintenance`) want a different new-code reference and sometimes a stricter
+quality gate than the project's main branch.
+
+!!! warning "Scaffold — admission only"
+    As of the current release, this CRD ships with full validation (CEL
+    rules, immutability of `spec.branch`, reserved-key rejection on
+    `spec.settings`) but the **reconcile pipeline is not yet
+    implemented**. Applying a `SonarQubeBranchRule` is accepted by the
+    API server, but no calls to SonarQube are made — the resource will
+    sit in `Pending` indefinitely. Tracked as a follow-up in the issue
+    tracker. Use this page as the contract the controller will satisfy
+    once shipped.
+
+| | |
+|---|---|
+| **API group** | `sonarqube.sonarqube.io` |
+| **API version** | `v1alpha1` |
+| **Kind** | `SonarQubeBranchRule` |
+| **Scope** | Namespaced |
+
+---
+
+## Complete example
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeBranchRule
+metadata:
+  name: backend-release-1x
+  namespace: sonarqube-prod
+spec:
+  # Required. Reference to the SonarQubeInstance hosting the project.
+  instanceRef:
+    name: sonarqube
+
+  # Required. The SonarQube project key the rule applies to.
+  # Should match an existing SonarQubeProject.spec.key on the same instance.
+  projectKey: myorg_backend-api
+
+  # Required. Branch name in SonarQube. Immutable — to retarget another
+  # branch, create a new BranchRule.
+  branch: release/1.x
+
+  # Optional. Per-branch new-code reference. See "newCodePeriod" below.
+  newCodePeriod:
+    mode: reference_branch
+    value: main
+
+  # Optional. Override the project's quality gate on this branch
+  # (SonarQube Enterprise+ feature).
+  qualityGate: strict-gate
+
+  # Optional. Branch-scoped sonar.* settings. Reserved auth keys
+  # (sonar.auth.*) are rejected at admission.
+  settings:
+    sonar.coverage.exclusions: "**/legacy/**,**/migrations/**"
+```
+
+---
+
+## Spec
+
+### `instanceRef`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Name of the target `SonarQubeInstance`. |
+| `namespace` | string | no | Defaults to the rule's own namespace. |
+
+### `projectKey`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | yes |
+| **Min length** | 1 |
+
+The SonarQube project key the rule attaches to. The operator does **not**
+verify that a `SonarQubeProject` with this key exists at admission time —
+the project may be created later, possibly by another process. The
+reconcile pipeline (once shipped) will keep the rule `Pending` until the
+project exists in SonarQube.
+
+### `branch`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | yes |
+| **Min length** | 1 |
+| **Immutable** | yes (enforced via CEL XValidation) |
+
+The branch name as known to SonarQube — typically the same as the Git
+branch (`main`, `release/1.x`, `develop`). Once a `SonarQubeBranchRule`
+has been created for a branch, the field is locked: to manage another
+branch, create a new resource. (Renaming a managed branch in SonarQube
+itself is out of scope; do that through the SonarQube UI or
+`/api/project_branches/rename` and update the spec to match.)
+
+### `newCodePeriod`
+
+Configures the per-branch new-code-period reference (the baseline
+SonarQube uses to decide what "new code" is). Maps to
+`POST /api/new_code_periods/set` with `project=<projectKey>&branch=<branch>`.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `mode` | enum | yes | One of `previous_version`, `days`, `date`, `reference_branch`. |
+| `value` | string | depends | Required for all modes **except** `previous_version`. Format depends on mode (see below). |
+
+#### `mode` semantics
+
+| Mode | `value` format | Meaning |
+|---|---|---|
+| `previous_version` | (omitted) | New code = anything since the previous SonarQube *project version* — set via `sonar.projectVersion` on analysis. |
+| `days` | integer | New code = anything analyzed in the last N days. Example: `value: "30"`. |
+| `date` | `YYYY-MM-DD` | New code = anything analyzed since this date. Example: `value: "2026-01-01"`. |
+| `reference_branch` | branch name | New code = the diff against the named branch (e.g. `main`). The recommended setting for long-lived release branches. |
+
+A CEL rule on the type rejects manifests where `value` is empty for any
+mode other than `previous_version`.
+
+### `qualityGate`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | no |
+
+The name of a SonarQube quality gate to attach **to this branch only**,
+overriding whatever gate the project as a whole uses. Maps to
+`POST /api/qualitygates/select?project=<projectKey>&branch=<branch>&gateName=<qualityGate>`.
+
+!!! note "Enterprise+ only"
+    Branch-level gate overrides are an Enterprise / Data Center Edition
+    feature. On Community, the call returns `400` and the rule will
+    surface `Failed`.
+
+### `settings`
+
+| | |
+|---|---|
+| **Type** | `map[string]string` |
+| **Required** | no |
+
+Branch-scoped `sonar.*` settings — typically used to relax coverage or
+duplications thresholds on legacy branches. Maps to
+`POST /api/settings/set?project=<projectKey>&branch=<branch>` for each
+key.
+
+A CEL rule rejects keys starting with `sonar.auth.` — those control
+instance-level authentication and have no business being managed
+per-branch.
+
+---
+
+## Status
+
+```yaml
+status:
+  phase: Ready
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: BranchRuleApplied
+      message: All branch-scoped settings applied to release/1.x
+      lastTransitionTime: "2026-04-26T09:45:00Z"
+```
+
+### `phase`
+
+| Phase | Meaning |
+|---|---|
+| `Pending` | Reconcile pipeline not yet implemented (current state) — or, once implemented, the target project does not yet exist on the instance. |
+| `Ready` | All branch-scoped settings have been applied. (Future) |
+| `Failed` | A SonarQube API call failed. (Future) |
+
+---
+
+## Lifecycle (planned)
+
+> The implementation below describes the intended reconcile behavior once
+> the controller is shipped. The current controller is an admission-only
+> scaffold; see the warning at the top of this page.
+
+### Creation
+
+1. Controller verifies the project exists via `GET /api/projects/search?projects=<projectKey>`.
+2. If `newCodePeriod` is set, calls `POST /api/new_code_periods/set`.
+3. If `qualityGate` is set, calls `POST /api/qualitygates/select` scoped
+   to the branch.
+4. For each entry in `settings`, calls `POST /api/settings/set` scoped to
+   the branch.
+5. `status.phase` transitions to `Ready`.
+
+### Deletion
+
+1. The controller resets each previously-managed setting via
+   `POST /api/settings/reset` scoped to the branch.
+2. If a `qualityGate` was selected, the operator unselects it, falling
+   back to the project's gate.
+3. The new-code-period reference is reset to the project default.
+4. Finalizer removed.
+
+---
+
+## Examples
+
+### Long-lived release branch with reference-branch new code
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeBranchRule
+metadata:
+  name: backend-release-1x
+  namespace: sonarqube-prod
+spec:
+  instanceRef:
+    name: sonarqube
+  projectKey: myorg_backend-api
+  branch: release/1.x
+  newCodePeriod:
+    mode: reference_branch
+    value: main
+```
+
+Any new finding on `release/1.x` is graded against `main` — perfect for
+back-porting workflows.
+
+### Legacy main branch with last-30-days new code
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeBranchRule
+metadata:
+  name: legacy-monolith-main
+  namespace: sonarqube-prod
+spec:
+  instanceRef:
+    name: sonarqube
+  projectKey: myorg_legacy-monolith
+  branch: main
+  newCodePeriod:
+    mode: days
+    value: "30"
+  settings:
+    sonar.coverage.exclusions: "**/legacy/**"
+```
+
+---
+
+## See also
+
+- [SonarQubeProject](sonarqubeproject.md) — the project the branch
+  belongs to.
+- [SonarQubeQualityGate](sonarqubequalitygate.md) — define the
+  per-branch quality gate referenced via `spec.qualityGate`.
+- [SonarQube new-code-period docs](https://docs.sonarsource.com/sonarqube/latest/project-administration/defining-new-code/).

--- a/docs/reference/crds/sonarqubegroup.md
+++ b/docs/reference/crds/sonarqubegroup.md
@@ -1,0 +1,197 @@
+# SonarQubeGroup
+
+A SonarQube group managed declaratively. The operator creates the group on
+the target instance, keeps its description in sync with the spec (drift
+correction), and deletes the group when the resource is removed.
+
+| | |
+|---|---|
+| **API group** | `sonarqube.sonarqube.io` |
+| **API version** | `v1alpha1` |
+| **Kind** | `SonarQubeGroup` |
+| **Scope** | Namespaced |
+
+---
+
+## Complete example
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeGroup
+metadata:
+  name: backend-team
+  namespace: sonarqube-prod
+spec:
+  # Required. Reference to the SonarQubeInstance hosting this group.
+  instanceRef:
+    name: sonarqube
+
+  # Required. Group name in SonarQube — unique per instance, immutable
+  # after creation.
+  name: backend-team
+
+  # Optional. Human-readable description shown in the SonarQube UI.
+  description: Backend developers — owners of the API and database tier.
+```
+
+---
+
+## Spec
+
+### `instanceRef`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Name of the target `SonarQubeInstance`. |
+| `namespace` | string | no | Defaults to the group's own namespace. |
+
+### `name`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | yes |
+| **Min length** | 1 |
+| **Immutable** | yes (enforced via CEL XValidation) |
+
+The unique group name in SonarQube. Used everywhere the group is
+referenced — user memberships (`SonarQubeUser.spec.groups`), project
+permissions (`SonarQubeProject.spec.permissions[].group`), permission
+templates. SonarQube has no rename API for groups, so the spec rejects
+updates outright; create a new group instead.
+
+### `description`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | no |
+
+Free-form description shown in the SonarQube UI (Administration →
+Security → Groups). Drift-corrected on every reconcile — if a SonarQube
+admin edits the description through the UI, the operator restores the
+spec value on the next cycle. Leave empty to clear it.
+
+---
+
+## Status
+
+```yaml
+status:
+  phase: Ready
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: GroupInSync
+      message: SonarQube group backend-team matches spec
+      lastTransitionTime: "2026-04-26T09:00:00Z"
+```
+
+### `phase`
+
+| Phase | Meaning |
+|---|---|
+| `Pending` | Target instance not yet `Ready`, or initial creation in progress. |
+| `Ready` | Group exists and its description matches the spec. |
+| `Failed` | A SonarQube API call failed. Inspect `conditions` and Events. |
+
+---
+
+## Lifecycle
+
+### Creation
+
+1. The controller calls `POST /api/user_groups/create` with the spec name
+   and description.
+2. `status.phase` transitions to `Ready`.
+
+### Updates and drift correction
+
+On every reconcile, the operator searches the live group by name and
+acts as follows:
+
+| Field | Behavior |
+|---|---|
+| `description` | If the live value differs from the spec, the operator calls `POST /api/user_groups/update`. True drift correction. |
+| `name` | Immutable per CEL XValidation; the API rejects updates. |
+
+### Deletion
+
+1. Resource marked with `deletionTimestamp`.
+2. The controller calls `POST /api/user_groups/delete` to remove the group
+   from SonarQube. Users that were members of the group lose those
+   memberships immediately, and project permissions granted to this
+   group are revoked SonarQube-side as part of the same call.
+3. Finalizer removed.
+
+If the SonarQube call fails (server unreachable, API error), the
+finalizer is removed anyway and the resource is deleted from Kubernetes.
+The SonarQube group may need a manual cleanup in that case.
+
+!!! warning "Cross-CRD coupling"
+    Deleting a `SonarQubeGroup` invalidates any `SonarQubeUser` that lists
+    the group in `spec.groups`, and any `SonarQubeProject` that grants
+    project permissions to it. The dependent reconcilers will start
+    failing until you either remove the references or recreate the
+    group.
+
+---
+
+## Examples
+
+### Minimal group
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeGroup
+metadata:
+  name: sonar-users
+  namespace: sonarqube-prod
+spec:
+  instanceRef:
+    name: sonarqube
+  name: sonar-users
+```
+
+### Group with description, used in a permission template
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeGroup
+metadata:
+  name: security-reviewers
+  namespace: sonarqube-prod
+spec:
+  instanceRef:
+    name: sonarqube
+  name: security-reviewers
+  description: Members allowed to administer security hotspots and review findings.
+---
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubePermissionTemplate
+metadata:
+  name: security-projects
+  namespace: sonarqube-prod
+spec:
+  instanceRef:
+    name: sonarqube
+  name: security-projects
+  projectKeyPattern: "myorg_security-.*"
+```
+
+The permission template above matches projects whose key starts with
+`myorg_security-`. Granting `securityhotspotadmin` on the template to the
+`security-reviewers` group is currently a manual step in the SonarQube UI
+(template-side permission grants will be promoted to spec fields in a
+follow-up).
+
+---
+
+## See also
+
+- [SonarQubeUser](sonarqubeuser.md) — `spec.groups` lists groups the user
+  should belong to.
+- [SonarQubeProject](sonarqubeproject.md) — `spec.permissions[].group`
+  grants project-scoped permissions to a group.
+- [SonarQubePermissionTemplate](sonarqubepermissiontemplate.md) — applies
+  permission grants to projects matching a key pattern.

--- a/docs/reference/crds/sonarqubeinstance.md
+++ b/docs/reference/crds/sonarqubeinstance.md
@@ -4,8 +4,10 @@ A managed SonarQube server. Creating a `SonarQubeInstance` provisions a
 `StatefulSet`, a `Service`, a `PersistentVolumeClaim` for SonarQube data, an
 optional `Ingress`, and bootstraps the admin password from a `Secret` you
 provide. Once `Ready`, every other CRD in this operator (`SonarQubePlugin`,
-`SonarQubeProject`, `SonarQubeQualityGate`, `SonarQubeUser`) can target this
-instance through `spec.instanceRef.name`.
+`SonarQubeProject`, `SonarQubeQualityGate`, `SonarQubeUser`,
+`SonarQubeGroup`, `SonarQubePermissionTemplate`, `SonarQubeWebhook`,
+`SonarQubeBranchRule`, `SonarQubeBackup`) can target this instance through
+`spec.instanceRef.name`.
 
 | | |
 |---|---|
@@ -74,6 +76,46 @@ spec:
   # Set to true on PSA-restricted clusters where this sysctls is configured
   # via DaemonSet, MachineConfig, or node tuning.
   skipSysctlInit: false
+
+  # Optional. Pod scheduling — passed verbatim to the StatefulSet pod template.
+  nodeSelector:
+    workload: sonarqube
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: sonarqube
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values: [amd64]
+
+  # Optional. Pod-level and container-level security contexts. The operator
+  # preserves a default fsGroup=1000 (matches the SonarQube image UID) when
+  # podSecurityContext is set without an explicit fsGroup.
+  podSecurityContext:
+    runAsNonRoot: true
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
+
+  # Optional. Prometheus ServiceMonitor for the operator's metrics endpoint.
+  monitoring:
+    enabled: true
+    scrapeInterval: 30s
+    labels:
+      release: kube-prometheus-stack
+
+  # Optional. Data Center Edition topology (Enterprise+ only).
+  cluster:
+    appNodes: 2
+    searchNodes: 3
+    licenseSecretRef: sonarqube-dce-license
 ```
 
 ---
@@ -220,6 +262,114 @@ configured on the node via:
 
 If `skipSysctlInit: true` is set on a node where `vm.max_map_count` is too
 low, Elasticsearch will fail to start with a clear log message.
+
+### `nodeSelector`
+
+| | |
+|---|---|
+| **Type** | `map[string]string` |
+| **Required** | no |
+
+Standard Kubernetes node-selector. Passed verbatim to the StatefulSet pod
+template. Use it to pin SonarQube to specific node pools — typical case is
+a memory-optimized pool, since SonarQube's embedded Elasticsearch wants at
+least 2 GB.
+
+### `tolerations`
+
+| | |
+|---|---|
+| **Type** | `[]corev1.Toleration` |
+| **Required** | no |
+
+Standard Kubernetes tolerations, passed verbatim to the pod template.
+Use to land SonarQube on tainted nodes (dedicated pools, GPU/spot
+exclusions, etc.).
+
+### `affinity`
+
+| | |
+|---|---|
+| **Type** | `*corev1.Affinity` |
+| **Required** | no |
+
+Standard Kubernetes affinity rules (node/pod affinity, anti-affinity).
+Passed verbatim to the pod template. The operator does not impose any
+default anti-affinity — for true HA, set it explicitly along with
+`spec.cluster` (Enterprise+ only).
+
+### `podSecurityContext`
+
+| | |
+|---|---|
+| **Type** | `*corev1.PodSecurityContext` |
+| **Required** | no |
+
+Pod-level security context. The operator's only opinionated default is
+`fsGroup: 1000`, which matches the UID baked into the official SonarQube
+image — without it, the data PVC ends up unreadable by the SonarQube
+process.
+
+When you supply your own `podSecurityContext`, the operator **keeps**
+`fsGroup: 1000` only if you didn't set `fsGroup` explicitly. Set
+`fsGroup` yourself to override.
+
+### `securityContext`
+
+| | |
+|---|---|
+| **Type** | `*corev1.SecurityContext` |
+| **Required** | no |
+
+Container-level security context applied to the SonarQube container
+**only**. Has no effect on the privileged `vm.max_map_count` init
+container — disable that one separately with `spec.skipSysctlInit`.
+
+Useful for satisfying Pod Security Admission `restricted` profile:
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  capabilities:
+    drop: [ALL]
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+### `monitoring`
+
+Configures a managed Prometheus `ServiceMonitor` (CRD provided by the
+Prometheus Operator) pointing at the operator's metrics endpoint. **Soft
+dependency**: if `monitoring.coreos.com/v1` is not installed in the
+cluster, the operator emits a `Degraded` condition rather than crashing.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `enabled` | bool | no | `false` | Create a ServiceMonitor for this instance. |
+| `scrapeInterval` | string | no | (Prometheus default) | Scrape interval, e.g. `30s`, `1m`. Validated by the regex `^[0-9]+(ms|s|m|h)$`. |
+| `labels` | `map[string]string` | no | `{}` | Labels added to the ServiceMonitor metadata. Used by Prometheus' `serviceMonitorSelector` to match. |
+
+The metrics surfaced are documented in [Reference → Metrics](../metrics.md).
+
+### `cluster`
+
+Configures SonarQube **Data Center Edition** (DCE) — multi-node topology
+for HA. Only valid when `edition: enterprise`; rejected at admission
+otherwise.
+
+| Field | Type | Required | Min | Description |
+|---|---|---|---|---|
+| `appNodes` | int32 | yes | 2 | Number of SonarQube application nodes. |
+| `searchNodes` | int32 | yes | 3 | Number of Elasticsearch search nodes. **Must be odd** (3, 5, 7…) so the cluster maintains quorum on a single node loss. CEL-validated at admission. |
+| `licenseSecretRef` | string | yes | — | Name of a Secret in the same namespace containing the DCE license under the key `license`. SonarQube DCE refuses to start without one. |
+
+!!! warning "Scaffold — single-StatefulSet rendering"
+    The `cluster` field is admission-validated today, but the operator
+    still renders a **single** StatefulSet. The two-StatefulSet
+    (app + search) DCE rendering is tracked as a follow-up. Setting
+    `cluster.*` will not yet give you HA — it just unlocks the field for
+    future use.
 
 ---
 

--- a/docs/reference/crds/sonarqubepermissiontemplate.md
+++ b/docs/reference/crds/sonarqubepermissiontemplate.md
@@ -1,0 +1,242 @@
+# SonarQubePermissionTemplate
+
+A SonarQube permission template managed declaratively. Permission templates
+define which users and groups get which project-level permissions
+(`admin`, `codeviewer`, `issueadmin`, `securityhotspotadmin`, `scan`,
+`user`) **automatically** when a new project's key matches the template's
+`projectKeyPattern`. They are the right primitive when you want to grant
+permissions to a *family* of projects rather than to one project at a
+time.
+
+| | |
+|---|---|
+| **API group** | `sonarqube.sonarqube.io` |
+| **API version** | `v1alpha1` |
+| **Kind** | `SonarQubePermissionTemplate` |
+| **Scope** | Namespaced |
+
+---
+
+## Complete example
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubePermissionTemplate
+metadata:
+  name: backend-projects
+  namespace: sonarqube-prod
+spec:
+  # Required. Reference to the SonarQubeInstance hosting this template.
+  instanceRef:
+    name: sonarqube
+
+  # Required. Template name — unique per instance, immutable after creation.
+  name: backend-projects
+
+  # Optional. Description shown in the SonarQube UI.
+  description: >-
+    Default permissions for projects under the backend team
+    (key prefix "myorg_backend-").
+
+  # Optional. Java regex of project keys this template applies to.
+  # Empty = template only applied manually via the UI.
+  projectKeyPattern: "myorg_backend-.*"
+
+  # Optional. Mark this template as the default applied to projects whose
+  # key does not match any other template. Default: false.
+  isDefault: false
+```
+
+---
+
+## Spec
+
+### `instanceRef`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Name of the target `SonarQubeInstance`. |
+| `namespace` | string | no | Defaults to the template's own namespace. |
+
+### `name`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | yes |
+| **Min length** | 1 |
+| **Immutable** | yes (enforced via CEL XValidation) |
+
+The unique template name in SonarQube. SonarQube has no rename API for
+templates, so the spec rejects updates outright.
+
+### `description`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | no |
+
+Free-form description shown in the SonarQube UI (Administration →
+Security → Permission Templates). Used as a comment for human readers —
+not drift-corrected today.
+
+### `projectKeyPattern`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | no |
+
+Java regular expression matched against new project keys. When a new
+project is created (via the UI, the API, or a `SonarQubeProject` CR) and
+its key matches the pattern, SonarQube applies the template's permission
+grants automatically.
+
+When **omitted or empty**, the template is only ever applied manually
+(via the SonarQube UI's *Apply Template* action). It still exists in
+SonarQube — but it does nothing on its own.
+
+Examples:
+
+| Pattern | Matches |
+|---|---|
+| `myorg_backend-.*` | Any project whose key starts with `myorg_backend-`. |
+| `.*` | Every project (effectively a default — but prefer `isDefault: true`). |
+| `team-a\\..*` | Projects with key prefix `team-a.` (escaped dot). |
+
+### `isDefault`
+
+| | |
+|---|---|
+| **Type** | bool |
+| **Required** | no |
+| **Default** | `false` |
+
+When `true`, the operator marks this template as the SonarQube
+**default** permission template — the one applied to any new project
+whose key matches no other template's `projectKeyPattern`. SonarQube
+allows exactly one default template at a time; setting another template
+to `isDefault: true` will displace whichever was default before.
+
+!!! warning "Last write wins"
+    The operator unconditionally calls `POST /api/permissions/set_default_template`
+    on every reconcile when `isDefault: true`. If two
+    `SonarQubePermissionTemplate` resources both have `isDefault: true`,
+    they will fight on every cycle — *don't do that*.
+
+---
+
+## Status
+
+```yaml
+status:
+  phase: Ready
+  templateId: AY-2pZ8sG9HJk0ABC-xyz
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: TemplateReady
+      message: SonarQube permission template backend-projects exists
+      lastTransitionTime: "2026-04-26T09:30:00Z"
+```
+
+### `phase`
+
+| Phase | Meaning |
+|---|---|
+| `Pending` | Target instance not yet `Ready`, or initial creation in progress. |
+| `Ready` | Template exists in SonarQube. |
+| `Failed` | A SonarQube API call failed. Inspect `conditions` and Events. |
+
+### Other status fields
+
+| Field | Description |
+|---|---|
+| `templateId` | The opaque template UUID returned by `POST /api/permissions/create_template`. Used by the operator to delete the template on resource removal. Do not edit. |
+
+---
+
+## Lifecycle
+
+### Creation
+
+1. The controller calls `POST /api/permissions/create_template` with the
+   spec name, description, and `projectKeyPattern`.
+2. The returned UUID is stored in `status.templateId`.
+3. If `isDefault: true`, the operator calls
+   `POST /api/permissions/set_default_template?templateName=<name>`.
+4. `status.phase` transitions to `Ready`.
+
+### Updates
+
+The current implementation reconciles only `isDefault` — every cycle
+re-asserts default-template status when set. **`projectKeyPattern` and
+`description` are not drift-corrected.** To change them today, delete
+the `SonarQubePermissionTemplate` and recreate it (or edit through the
+UI as a one-off).
+
+Permission grants on the template (i.e. *which* groups/users get *which*
+permissions when the template fires) are **not yet manageable through the
+spec**. Add them through the SonarQube UI or `/api/permissions/add_*_to_template`
+calls — a future revision of this CRD will surface them as
+`spec.permissions[]`. Tracked in the issue tracker.
+
+### Deletion
+
+1. Resource marked with `deletionTimestamp`.
+2. The controller calls `POST /api/permissions/delete_template?templateId=<status.templateId>`.
+   SonarQube removes the template, but **does not retro-revoke
+   permissions on projects** that already had this template applied —
+   those grants stick.
+3. If this was the SonarQube default template, SonarQube falls back to
+   its built-in factory default. Set another `SonarQubePermissionTemplate`
+   to `isDefault: true` first if you want a controlled handoff.
+4. Finalizer removed.
+
+---
+
+## Examples
+
+### Backend projects template, default
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubePermissionTemplate
+metadata:
+  name: default-template
+  namespace: sonarqube-prod
+spec:
+  instanceRef:
+    name: sonarqube
+  name: default-template
+  description: Catch-all template for any project whose key has no other match.
+  projectKeyPattern: ".*"
+  isDefault: true
+```
+
+### Per-team template, manual application
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubePermissionTemplate
+metadata:
+  name: payments-team
+  namespace: sonarqube-prod
+spec:
+  instanceRef:
+    name: sonarqube
+  name: payments-team
+  description: Tighter permissions for the regulated payments scope. Apply manually.
+  # No projectKeyPattern → only applied via the UI's "Apply Template" action.
+```
+
+---
+
+## See also
+
+- [SonarQubeGroup](sonarqubegroup.md) — the groups that templates grant
+  permissions to.
+- [SonarQubeProject](sonarqubeproject.md) — `spec.permissions[]` for
+  one-off, per-project grants instead of template-wide ones.
+- [SonarQube permission templates docs](https://docs.sonarsource.com/sonarqube/latest/instance-administration/security/#permission-templates).

--- a/docs/reference/crds/sonarqubeproject.md
+++ b/docs/reference/crds/sonarqubeproject.md
@@ -50,6 +50,35 @@ spec:
     enabled: true
     secretName: hello-world-ci-token   # default: <project-name>-ci-token
     expiresIn: 720h                    # optional, e.g. 30 days
+
+  # Optional. Project tags. Reconciled with set semantics — SonarQube's
+  # tag list is replaced by this list on each reconcile.
+  tags:
+    - backend
+    - python
+
+  # Optional. Project links shown on the project overview page.
+  # Operator only removes links it created (tracked via status.managedLinkNames).
+  links:
+    - name: Repository
+      url: https://github.com/myorg/hello-world
+    - name: CI
+      url: https://github.com/myorg/hello-world/actions
+
+  # Optional. Project-scoped sonar.* settings. Reserved auth keys
+  # (sonar.auth.*) are rejected at admission.
+  settings:
+    sonar.coverage.exclusions: "**/migrations/**,**/*.generated.go"
+    sonar.exclusions: "**/vendor/**"
+
+  # Optional. Project-scoped permission grants. Operator only ever removes
+  # grants it created (tracked via status.managedPermissions); permissions
+  # set through the SonarQube UI are left alone.
+  permissions:
+    - group: backend-team
+      permissions: [admin, codeviewer, scan]
+    - user: ci-bot
+      permissions: [scan]
 ```
 
 ---
@@ -184,6 +213,99 @@ will fail with `401 Unauthorized` and you must trigger a rotation
 manually (delete the Secret or set the annotation). See the
 [Token Rotation guide](../../how-to/token-rotation.md) for the workflow.
 
+### `tags`
+
+| | |
+|---|---|
+| **Type** | `[]string` |
+| **Required** | no |
+
+The full set of tags to apply to the project. **Set semantics, full
+ownership**: on each reconcile, SonarQube's tag list for this project is
+replaced by `spec.tags`. Tags added to the project through the UI will
+be removed on the next reconcile.
+
+If you need tags that the operator does *not* manage (e.g. tags applied
+by a separate tagging script), do not list any tags in `spec.tags` and
+manage them all out-of-band. The operator does not have a per-tag opt-out.
+
+### `links`
+
+| | |
+|---|---|
+| **Type** | `[]ProjectLink` |
+| **Required** | no |
+
+List of named URLs shown on the project's overview page. SonarQube infers
+the link *type* (`homepage`, `ci`, `issue`, `scm`, `scm_dev`, `other`)
+from the link **name** automatically — the create API does not take a
+type argument.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Link display name. Conventional names are auto-typed by SonarQube (e.g. `Homepage`, `CI`, `Issue Tracker`, `SCM`). |
+| `url` | string | yes | Link target URL. |
+
+The operator follows a "manage what I created" rule: only links whose
+names appear in `status.managedLinkNames` are removed when they leave
+the spec. Links added directly through the SonarQube UI stay untouched.
+
+### `settings`
+
+| | |
+|---|---|
+| **Type** | `map[string]string` |
+| **Required** | no |
+
+Project-scoped `sonar.*` properties. Each entry is propagated to
+`POST /api/settings/set?component=<key>`; entries removed from the spec
+that the operator previously owned (tracked in `status.managedSettings`)
+are reset via `POST /api/settings/reset`.
+
+A CEL rule rejects keys starting with `sonar.auth.` — those control
+instance-level authentication and have no business being managed
+per-project.
+
+Common values:
+
+| Key | Effect |
+|---|---|
+| `sonar.coverage.exclusions` | Glob list of files excluded from coverage reporting. |
+| `sonar.exclusions` | Glob list of files completely excluded from analysis. |
+| `sonar.cpd.exclusions` | Glob list of files excluded from duplication detection. |
+| `sonar.sources` | Source code roots (defaults to project root if unset). |
+
+### `permissions`
+
+| | |
+|---|---|
+| **Type** | `[]ProjectPermission` |
+| **Required** | no |
+
+Project-scoped permission grants. Each entry grants **a list of
+permissions** to **either a user or a group** (a CEL rule rejects entries
+that set both or neither).
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `user` | string | conditional | SonarQube login. Mutually exclusive with `group`. |
+| `group` | string | conditional | SonarQube group name. Mutually exclusive with `user`. |
+| `permissions` | `[]string` | yes | Permissions to grant. **Min items: 1.** Valid values: `admin`, `codeviewer`, `issueadmin`, `securityhotspotadmin`, `scan`, `user`. |
+
+The operator follows the same "manage what I created" rule as `groups` on
+`SonarQubeUser`. Only grants that appear in `status.managedPermissions`
+(format: `<kind>:<subject>:<permission>`, e.g. `group:backend-team:admin`)
+are removed when they leave the spec. Grants added through the SonarQube
+UI or through a `SonarQubePermissionTemplate` apply are never touched.
+
+!!! note "Project permissions vs. permission templates"
+    Use `spec.permissions` for permanent, project-specific grants
+    (e.g. *the backend team always gets admin on this project*). Use a
+    `SonarQubePermissionTemplate` for grants applied automatically to a
+    *family* of projects whose key matches a pattern. The two coexist:
+    a project gets its template-applied grants on creation, and any
+    explicit `spec.permissions` on top of that.
+
 ---
 
 ## Status
@@ -215,6 +337,9 @@ status:
 |---|---|
 | `projectUrl` | Direct dashboard link to the project on the SonarQube UI. |
 | `tokenSecretRef` | Name of the Secret holding the CI token. Set when `ciToken.enabled: true`. |
+| `managedLinkNames` | Names of project links the operator created. Used to decide which links to remove when they leave `spec.links`. Never edit by hand. |
+| `managedSettings` | Setting keys the operator currently owns. Keys removed from `spec.settings` but still in this list are reset on the next reconcile. Never edit by hand. |
+| `managedPermissions` | Permission grants the operator currently owns, formatted as `user:<login>:<perm>` / `group:<name>:<perm>`. Grants no longer matching `spec.permissions` are revoked. Never edit by hand. |
 
 ---
 

--- a/docs/reference/crds/sonarqubeuser.md
+++ b/docs/reference/crds/sonarqubeuser.md
@@ -48,6 +48,32 @@ spec:
   groups:
     - sonar-users
     - backend-team
+
+  # Optional. SCM identities (Git committer emails / names) linked to this
+  # user. Set semantics: SonarQube's SCM account list is replaced by this
+  # list on each reconcile.
+  scmAccounts:
+    - john.doe@example.com
+    - jdoe@github
+
+  # Optional. Standalone user tokens stored in Kubernetes Secrets.
+  # Independent of any project — for personal automation, read-only API
+  # access, or a global analysis token.
+  tokens:
+    - name: read-only-api
+      type: USER_TOKEN
+      secretName: john-doe-readonly-token
+      expiresIn: 8760h               # optional, 1 year
+    - name: global-analysis
+      type: GLOBAL_ANALYSIS_TOKEN
+      secretName: org-analysis-token
+
+  # Optional. Instance-wide permissions granted to this user.
+  # The operator only ever revokes grants it created (tracked via
+  # status.managedGlobalPermissions).
+  globalPermissions:
+    - scan
+    - profileadmin
 ```
 
 ---
@@ -168,6 +194,85 @@ This means the operator can coexist safely with LDAP / SAML group sync,
 SCIM provisioners, and manual UI grants. It will never fight to remove a
 group it didn't add.
 
+### `scmAccounts`
+
+| | |
+|---|---|
+| **Type** | `[]string` |
+| **Required** | no |
+
+The SCM identities (Git committer emails, GitHub handles, internal usernames…)
+SonarQube should attribute analysis findings to. When a `git blame` line in
+an analyzed project resolves to one of these identities, SonarQube credits
+the issue to this user — useful for the *author of the issue* facet, the
+*new code introduced by* metric, and personal dashboards.
+
+**Set semantics**: on each reconcile, SonarQube's SCM account list for
+this user is replaced by `spec.scmAccounts`. Pass an empty list (or omit
+the field once it was previously set) to clear all accounts. There is no
+per-account opt-out — the field is fully owned by the operator.
+
+Common entries: the user's primary commit email, alternate emails (work
+vs. personal), and any internal usernames pre-dating consistent email
+hygiene.
+
+### `tokens`
+
+| | |
+|---|---|
+| **Type** | `[]UserToken` |
+| **Required** | no |
+
+Standalone SonarQube user tokens, each materialized as its own Kubernetes
+Secret in the user's namespace. Distinct from `SonarQubeProject.spec.ciToken`
+(which is a per-project analysis token tied to the project's lifecycle):
+these are user-scoped tokens for personal automation, read-only API access,
+or a global-analysis token shared by many CI pipelines.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `name` | string | yes | — | SonarQube-side token name. Must be unique per user. |
+| `type` | enum | no | `USER_TOKEN` | `USER_TOKEN` (full user permissions) or `GLOBAL_ANALYSIS_TOKEN` (analysis-only, no read of the rest of the API). |
+| `secretName` | string | yes | — | Name of the Kubernetes Secret to store the token under the key `token`. |
+| `expiresIn` | duration | no | — (no expiry) | Optional Go-style duration: `720h` (30 days), `8760h` (1 year). Passed through to SonarQube as the token's `expirationDate`. |
+
+The operator follows "manage what I created": only token names that
+appear in `status.managedTokens` are revoked when they leave the spec.
+Tokens generated through the SonarQube UI are never touched.
+
+**Rotation**: delete the Secret to force the operator to regenerate the
+token on the next reconcile (the previous SonarQube-side token is
+revoked as part of the same cycle). The operator does **not** auto-rotate
+before `expiresIn` — see the [Token Rotation guide](../../how-to/token-rotation.md)
+for scheduled-rotation patterns.
+
+### `globalPermissions`
+
+| | |
+|---|---|
+| **Type** | `[]string` |
+| **Required** | no |
+
+Instance-wide permissions granted to this user. Valid values:
+
+| Permission | Effect |
+|---|---|
+| `admin` | Full instance administration. Use sparingly. |
+| `gateadmin` | Create / edit / delete quality gates. |
+| `profileadmin` | Create / edit / delete quality profiles. |
+| `provisioning` | Create new projects. |
+| `scan` | Execute analysis. The default permission for CI bots. |
+
+The operator follows "manage what I created": only grants that appear in
+`status.managedGlobalPermissions` are revoked when they leave the spec.
+Permissions assigned through the SonarQube UI are never removed.
+
+!!! warning "`admin` is highly privileged"
+    A user with `admin` can change the admin password, install plugins,
+    manage all users and groups, and see every project regardless of
+    visibility. Prefer narrow, role-based grants (`gateadmin`,
+    `profileadmin`) and reserve `admin` for break-glass accounts.
+
 ---
 
 ## Status
@@ -201,6 +306,8 @@ status:
 |---|---|
 | `active` | Whether the user account is currently active in SonarQube. False after deletion (operator deactivates rather than hard-deletes). |
 | `groups` | Groups the operator has assigned. Used for the "manage what I created" diff (see above). Never edit by hand. |
+| `managedTokens` | Names of standalone tokens the operator generated for this user. Names removed from `spec.tokens` but still in this list are revoked on the next reconcile. Never edit by hand. |
+| `managedGlobalPermissions` | Global permissions the operator granted to this user. Permissions no longer in `spec.globalPermissions` are revoked on the next reconcile. Never edit by hand. |
 
 ---
 

--- a/docs/reference/crds/sonarqubewebhook.md
+++ b/docs/reference/crds/sonarqubewebhook.md
@@ -1,0 +1,250 @@
+# SonarQubeWebhook
+
+A SonarQube webhook managed declaratively. SonarQube webhooks are HTTP
+callbacks invoked at the end of every analysis (project-scoped) or every
+analysis on the instance (global). Common targets: Slack/Teams notifiers,
+release-pipeline gates that block on the quality-gate result, dashboards.
+
+| | |
+|---|---|
+| **API group** | `sonarqube.sonarqube.io` |
+| **API version** | `v1alpha1` |
+| **Kind** | `SonarQubeWebhook` |
+| **Scope** | Namespaced |
+
+---
+
+## Complete example
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeWebhook
+metadata:
+  name: backend-slack-notify
+  namespace: sonarqube-prod
+spec:
+  # Required. Reference to the SonarQubeInstance hosting this webhook.
+  instanceRef:
+    name: sonarqube
+
+  # Required. Display name shown in the SonarQube UI.
+  name: backend-slack-notify
+
+  # Required. The HTTP(S) endpoint SonarQube POSTs to at the end of analysis.
+  url: https://hooks.slack.com/services/T000/B000/XXXXXXXXXXXX
+
+  # Optional. SonarQube project key to scope the webhook to. When set, only
+  # analyses on this project trigger the webhook. When omitted, the webhook
+  # is global (admin-only — SonarQube enforces this).
+  projectKey: myorg_backend-api
+
+  # Optional. Reference to a Secret with key "secret". SonarQube uses it to
+  # HMAC-sign the payload (header X-Sonar-Webhook-HMAC-SHA256), letting
+  # the receiver verify the call really came from this SonarQube.
+  secretRef:
+    name: backend-slack-webhook-secret
+```
+
+---
+
+## Spec
+
+### `instanceRef`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Name of the target `SonarQubeInstance`. |
+| `namespace` | string | no | Defaults to the webhook's own namespace. |
+
+### `name`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | yes |
+| **Min length** | 1 |
+
+Display name shown in SonarQube's webhooks page. Free-form. SonarQube
+enforces unique names within a project (or globally for admin-scoped
+webhooks).
+
+### `url`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | yes |
+| **Pattern** | `^https?://.+` |
+
+The endpoint SonarQube `POST`s the analysis report to. SonarQube's payload
+format is documented at
+[docs.sonarsource.com → Webhooks](https://docs.sonarsource.com/sonarqube/latest/project-administration/webhooks/).
+Schemes other than `http` / `https` are rejected at admission.
+
+!!! warning "Egress"
+    SonarQube needs network egress to your `url`. If your cluster has
+    egress restrictions (NetworkPolicy, service mesh, corporate proxy),
+    make sure the SonarQube pod can reach the endpoint — otherwise the
+    webhook silently fails on every analysis with no signal in the
+    operator's status.
+
+### `projectKey`
+
+| | |
+|---|---|
+| **Type** | string |
+| **Required** | no |
+
+SonarQube project key the webhook is scoped to. Should match an existing
+`SonarQubeProject.spec.key` on the same instance.
+
+When **omitted**, the webhook is **global** — SonarQube fires it on every
+analysis on the instance. Global webhooks can only be created by an admin,
+so the operator's admin token (issued during `SonarQubeInstance`
+bootstrap) is what authorizes this path.
+
+### `secretRef`
+
+| | |
+|---|---|
+| **Type** | `LocalObjectReference` |
+| **Required** | no |
+
+Reference to a Secret in the same namespace containing the HMAC signing
+secret under the key `secret`. When set, SonarQube includes a
+`X-Sonar-Webhook-HMAC-SHA256` header on every webhook call computed as
+`HMAC-SHA256(secret, body)`.
+
+The receiver verifies that header before trusting the payload. **Always
+use a `secretRef` for webhooks reachable on the public internet** — without
+it, anyone who knows the URL can forge analysis reports.
+
+The operator reads the Secret only at create time. **Updating the value
+after the webhook exists does not rotate the SonarQube-side secret.** To
+rotate, delete the `SonarQubeWebhook` and recreate it (or recreate the
+Secret with the new value, then `kubectl annotate` the webhook to force a
+re-create — see follow-up issues).
+
+---
+
+## Status
+
+```yaml
+status:
+  phase: Ready
+  webhookKey: AY-1cZxs5OQjY0Wm-aBC
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: WebhookCreated
+      message: SonarQube webhook backend-slack-notify exists
+      lastTransitionTime: "2026-04-26T09:15:00Z"
+```
+
+### `phase`
+
+| Phase | Meaning |
+|---|---|
+| `Pending` | Target instance not yet `Ready`, or initial creation in progress. |
+| `Ready` | Webhook exists in SonarQube. |
+| `Failed` | A SonarQube API call failed. Inspect `conditions` and Events. |
+
+### Other status fields
+
+| Field | Description |
+|---|---|
+| `webhookKey` | The opaque key returned by `POST /api/webhooks/create`. Used by the operator to delete the webhook on resource removal. Do not edit. |
+
+---
+
+## Lifecycle
+
+### Creation
+
+1. The controller calls `POST /api/webhooks/create` with the spec name,
+   URL, optional `project=<projectKey>`, and optional `secret=<value>`
+   (from `secretRef`).
+2. `status.webhookKey` is populated with the SonarQube-assigned key.
+3. `status.phase` transitions to `Ready`.
+
+### Updates
+
+The current implementation does **not** drift-correct webhook fields.
+Once created, the SonarQube-side webhook keeps whatever name, URL, and
+secret were set at create time, even if you edit `spec.url` or
+`spec.name`. Drift correction (delete + re-create on diff) is a follow-up.
+
+If you need to change the URL or rotate the HMAC secret today, delete the
+`SonarQubeWebhook` and recreate it.
+
+### Deletion
+
+1. Resource marked with `deletionTimestamp`.
+2. The controller calls `POST /api/webhooks/delete?webhook=<status.webhookKey>`.
+3. Finalizer removed.
+
+If the SonarQube call fails, the finalizer is removed anyway and the
+resource is deleted from Kubernetes. The SonarQube webhook may need a
+manual cleanup via the UI in that case.
+
+---
+
+## Examples
+
+### Slack notifier on a single project
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend-slack-webhook-secret
+  namespace: sonarqube-prod
+type: Opaque
+stringData:
+  secret: '<long-random-string>'
+---
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeWebhook
+metadata:
+  name: backend-slack
+  namespace: sonarqube-prod
+spec:
+  instanceRef:
+    name: sonarqube
+  name: backend-slack
+  url: https://hooks.slack.com/services/T000/B000/XXXXXXXXXXXX
+  projectKey: myorg_backend-api
+  secretRef:
+    name: backend-slack-webhook-secret
+```
+
+### Global webhook to a release-gate service
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeWebhook
+metadata:
+  name: release-gate
+  namespace: sonarqube-prod
+spec:
+  instanceRef:
+    name: sonarqube
+  # No projectKey → global webhook, admin-scoped.
+  name: release-gate
+  url: https://release-gate.svc.cluster.local/sonarqube
+  secretRef:
+    name: release-gate-shared-secret
+```
+
+The release-gate service can then verify
+`X-Sonar-Webhook-HMAC-SHA256` against the shared secret before honoring
+the analysis result.
+
+---
+
+## See also
+
+- [SonarQubeProject](sonarqubeproject.md) — the projects whose analyses
+  trigger project-scoped webhooks.
+- [SonarQube webhooks documentation](https://docs.sonarsource.com/sonarqube/latest/project-administration/webhooks/)
+  — payload format, header reference.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,11 +6,16 @@ Exhaustive documentation for every API, value, and metric the operator exposes.
 
 | Kind | Purpose |
 |---|---|
-| [SonarQubeInstance](crds/sonarqubeinstance.md) | A managed SonarQube server (StatefulSet + Service + PVC + optional Ingress) |
+| [SonarQubeInstance](crds/sonarqubeinstance.md) | A managed SonarQube server (StatefulSet + Service + PVC + optional Ingress, scheduling, security context, ServiceMonitor, DCE topology) |
 | [SonarQubePlugin](crds/sonarqubeplugin.md) | A plugin installed in a SonarQube instance |
-| [SonarQubeProject](crds/sonarqubeproject.md) | A SonarQube project with declarative visibility, quality gate and CI token |
+| [SonarQubeProject](crds/sonarqubeproject.md) | A SonarQube project with declarative visibility, quality gate, CI token, tags, links, settings, permissions |
 | [SonarQubeQualityGate](crds/sonarqubequalitygate.md) | A quality gate with drift detection |
-| [SonarQubeUser](crds/sonarqubeuser.md) | A SonarQube user with declarative group membership |
+| [SonarQubeUser](crds/sonarqubeuser.md) | A SonarQube user with declarative groups, SCM accounts, standalone tokens, global permissions |
+| [SonarQubeGroup](crds/sonarqubegroup.md) | A SonarQube group, drift-corrected |
+| [SonarQubePermissionTemplate](crds/sonarqubepermissiontemplate.md) | A permission template applied automatically by project-key pattern |
+| [SonarQubeWebhook](crds/sonarqubewebhook.md) | Project-scoped or global webhook (HMAC-signed) |
+| [SonarQubeBranchRule](crds/sonarqubebranchrule.md) | Per-branch new-code-period, gate override, settings *(scaffold — admission only)* |
+| [SonarQubeBackup](crds/sonarqubebackup.md) | Scheduled backup (`pg_dump` + extensions PVC) to PVC or S3 *(scaffold — admission only)* |
 
 ## Operator surface
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,11 @@ nav:
           - SonarQubeProject: reference/crds/sonarqubeproject.md
           - SonarQubeQualityGate: reference/crds/sonarqubequalitygate.md
           - SonarQubeUser: reference/crds/sonarqubeuser.md
+          - SonarQubeGroup: reference/crds/sonarqubegroup.md
+          - SonarQubePermissionTemplate: reference/crds/sonarqubepermissiontemplate.md
+          - SonarQubeWebhook: reference/crds/sonarqubewebhook.md
+          - SonarQubeBranchRule: reference/crds/sonarqubebranchrule.md
+          - SonarQubeBackup: reference/crds/sonarqubebackup.md
       - Helm Values: reference/helm-values.md
       - Metrics: reference/metrics.md
       - SonarQube API: reference/sonarqube-api.md


### PR DESCRIPTION
## Summary

Brings the documentation back in sync with the code shipped across the
last 17 feature PRs (`#26`–`#42`).

**5 new CRD reference pages**:
- `SonarQubeGroup` — full reconcile, drift correction on description.
- `SonarQubePermissionTemplate` — full reconcile, default-template assertion.
- `SonarQubeWebhook` — full reconcile, project-scoped or global, HMAC secret support.
- `SonarQubeBranchRule` — clearly marked **scaffold (admission only)**, reconcile pipeline tracked as a follow-up.
- `SonarQubeBackup` — clearly marked **scaffold (admission only)**, reconcile pipeline tracked as a follow-up.

**3 existing CRD references enriched**:
- `SonarQubeInstance` — `nodeSelector`, `tolerations`, `affinity`, `podSecurityContext`, `securityContext`, `monitoring` (ServiceMonitor), `cluster` (DCE — flagged scaffold rendering).
- `SonarQubeProject` — `tags` (set semantics), `links`, `settings`, `permissions`, plus the new `managed*` status fields.
- `SonarQubeUser` — `scmAccounts`, `tokens` (with `USER_TOKEN` / `GLOBAL_ANALYSIS_TOKEN`), `globalPermissions`, plus the new `managed*` status fields.

**Meta-doc**:
- `README.md` — table of all 10 CRDs with scaffold flags.
- `ROADMAP.md` — moves Group/PermissionTemplate/Webhook/BranchRule/Backup out of "Beyond v1.0.0" into the appropriate sections; lists the remaining scaffold reconcile pipelines as the new beyond-v1 work.
- `docs/index.md`, `docs/reference/index.md`, `mkdocs.yml` nav.

## Test plan

- [ ] `mkdocs build` locally with no warnings on dead links / unknown nav entries.
- [ ] Skim each new CRD page rendered to confirm tables and admonitions look right.
- [ ] Confirm scaffold callouts (BranchRule, Backup, Instance.cluster) are visible at the top of those sections.