### PR TITLE
fix: v0.5.0 release-blockers and hardening

### DIFF
--- a/charts/sonarqube-operator/Chart.yaml
+++ b/charts/sonarqube-operator/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: sonarqube-operator
 description: |
   A Kubernetes operator that manages the full lifecycle of SonarQube and its
-  configuration as code: instances, plugins, projects, quality gates and users.
+  configuration as code: instances, plugins, projects, quality gates, users,
+  groups, permission templates, webhooks, branch rules and backups.
 type: application
 kubeVersion: ">=1.27.0-0"
 version: 0.5.0
@@ -50,3 +51,28 @@ annotations:
       name: sonarqubeusers.sonarqube.sonarqube.io
       displayName: SonarQube User
       description: A SonarQube user with declarative group membership.
+    - kind: SonarQubeGroup
+      version: v1alpha1
+      name: sonarqubegroups.sonarqube.sonarqube.io
+      displayName: SonarQube Group
+      description: A SonarQube group managed declaratively.
+    - kind: SonarQubePermissionTemplate
+      version: v1alpha1
+      name: sonarqubepermissiontemplates.sonarqube.sonarqube.io
+      displayName: SonarQube Permission Template
+      description: A permission template applied automatically to projects matching a key pattern.
+    - kind: SonarQubeWebhook
+      version: v1alpha1
+      name: sonarqubewebhooks.sonarqube.sonarqube.io
+      displayName: SonarQube Webhook
+      description: A SonarQube webhook (project-scoped or global) with HMAC signing.
+    - kind: SonarQubeBranchRule
+      version: v1alpha1
+      name: sonarqubebranchrules.sonarqube.sonarqube.io
+      displayName: SonarQube Branch Rule
+      description: Per-branch new-code-period, gate override and settings (scaffold).
+    - kind: SonarQubeBackup
+      version: v1alpha1
+      name: sonarqubebackups.sonarqube.sonarqube.io
+      displayName: SonarQube Backup
+      description: Scheduled pg_dump + extensions snapshot to PVC or S3 (scaffold).

--- a/charts/sonarqube-operator/templates/aggregated-roles.yaml
+++ b/charts/sonarqube-operator/templates/aggregated-roles.yaml
@@ -44,7 +44,18 @@ aggregationRule:
         sonarqube.sonarqube.io/aggregate-to-viewer: "true"
 rules: []
 ---
-{{- $kinds := list "sonarqubeinstances" "sonarqubeplugins" "sonarqubeprojects" "sonarqubequalitygates" "sonarqubeusers" -}}
+{{- $kinds := list
+  "sonarqubebackups"
+  "sonarqubebranchrules"
+  "sonarqubegroups"
+  "sonarqubeinstances"
+  "sonarqubepermissiontemplates"
+  "sonarqubeplugins"
+  "sonarqubeprojects"
+  "sonarqubequalitygates"
+  "sonarqubeusers"
+  "sonarqubewebhooks"
+-}}
 {{- range $kinds }}
 {{- $kind := . }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/sonarqube-operator/templates/clusterrole.yaml
+++ b/charts/sonarqube-operator/templates/clusterrole.yaml
@@ -20,32 +20,51 @@ rules:
     resources:
       - statefulsets
     verbs: [create, delete, get, list, patch, update, watch]
+  - apiGroups: [batch]
+    resources:
+      - cronjobs
+    verbs: [create, delete, get, list, patch, update, watch]
   - apiGroups: [networking.k8s.io]
     resources:
       - ingresses
     verbs: [create, delete, get, list, patch, update, watch]
   - apiGroups: [sonarqube.sonarqube.io]
     resources:
+      - sonarqubebackups
+      - sonarqubebranchrules
+      - sonarqubegroups
       - sonarqubeinstances
+      - sonarqubepermissiontemplates
       - sonarqubeplugins
       - sonarqubeprojects
       - sonarqubequalitygates
       - sonarqubeusers
+      - sonarqubewebhooks
     verbs: [create, delete, get, list, patch, update, watch]
   - apiGroups: [sonarqube.sonarqube.io]
     resources:
+      - sonarqubebackups/finalizers
+      - sonarqubebranchrules/finalizers
+      - sonarqubegroups/finalizers
       - sonarqubeinstances/finalizers
+      - sonarqubepermissiontemplates/finalizers
       - sonarqubeplugins/finalizers
       - sonarqubeprojects/finalizers
       - sonarqubequalitygates/finalizers
       - sonarqubeusers/finalizers
+      - sonarqubewebhooks/finalizers
     verbs: [update]
   - apiGroups: [sonarqube.sonarqube.io]
     resources:
+      - sonarqubebackups/status
+      - sonarqubebranchrules/status
+      - sonarqubegroups/status
       - sonarqubeinstances/status
+      - sonarqubepermissiontemplates/status
       - sonarqubeplugins/status
       - sonarqubeprojects/status
       - sonarqubequalitygates/status
       - sonarqubeusers/status
+      - sonarqubewebhooks/status
     verbs: [get, patch, update]
 {{- end }}

--- a/charts/sonarqube-operator/templates/deployment.yaml
+++ b/charts/sonarqube-operator/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
             {{- end }}
             {{- if .Values.webhook.enabled }}
             - --enable-webhook
+            - --webhook-port={{ .Values.webhook.port }}
             - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
             {{- end }}
             {{- with .Values.extraArgs }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,8 +87,11 @@ func main() {
 		"If set, the validating webhook server will be started. Requires TLS certificates (e.g. via cert-manager).")
 	flag.IntVar(&webhookPort, "webhook-port", 9443,
 		"The port the validating webhook server binds to. Must match the targetPort of the webhook Service.")
+	// Production-friendly defaults: JSON encoding, structured stack traces only
+	// on errors, sane sampling. Override at deploy time with --zap-devel for the
+	// verbose human-readable console output suited to local `make run`.
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,7 @@ func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
+	var webhookPort int
 	var enableLeaderElection bool
 	var enableWebhook bool
 	var probeAddr string
@@ -84,6 +85,8 @@ func main() {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.BoolVar(&enableWebhook, "enable-webhook", false,
 		"If set, the validating webhook server will be started. Requires TLS certificates (e.g. via cert-manager).")
+	flag.IntVar(&webhookPort, "webhook-port", 9443,
+		"The port the validating webhook server binds to. Must match the targetPort of the webhook Service.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -110,6 +113,7 @@ func main() {
 	// Initial webhook TLS options
 	webhookTLSOpts := tlsOpts
 	webhookServerOptions := webhook.Options{
+		Port:    webhookPort,
 		TLSOpts: webhookTLSOpts,
 	}
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,6 +6,12 @@ resources:
 - bases/sonarqube.sonarqube.io_sonarqubeplugins.yaml
 - bases/sonarqube.sonarqube.io_sonarqubeprojects.yaml
 - bases/sonarqube.sonarqube.io_sonarqubequalitygates.yaml
+- bases/sonarqube.sonarqube.io_sonarqubeusers.yaml
+- bases/sonarqube.sonarqube.io_sonarqubegroups.yaml
+- bases/sonarqube.sonarqube.io_sonarqubepermissiontemplates.yaml
+- bases/sonarqube.sonarqube.io_sonarqubewebhooks.yaml
+- bases/sonarqube.sonarqube.io_sonarqubebranchrules.yaml
+- bases/sonarqube.sonarqube.io_sonarqubebackups.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -5,4 +5,9 @@ resources:
 - sonarqube_v1alpha1_sonarqubeproject.yaml
 - sonarqube_v1alpha1_sonarqubequalitygate.yaml
 - sonarqube_v1alpha1_sonarqubeuser.yaml
+- sonarqube_v1alpha1_sonarqubegroup.yaml
+- sonarqube_v1alpha1_sonarqubepermissiontemplate.yaml
+- sonarqube_v1alpha1_sonarqubewebhook.yaml
+- sonarqube_v1alpha1_sonarqubebranchrule.yaml
+- sonarqube_v1alpha1_sonarqubebackup.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/sonarqube_v1alpha1_sonarqubebackup.yaml
+++ b/config/samples/sonarqube_v1alpha1_sonarqubebackup.yaml
@@ -1,0 +1,13 @@
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeBackup
+metadata:
+  name: nightly
+  namespace: default
+spec:
+  instanceRef:
+    name: my-sonarqube
+  schedule: "0 2 * * *"
+  retention: 7
+  destination:
+    pvc:
+      claimName: sonarqube-backups

--- a/config/samples/sonarqube_v1alpha1_sonarqubebranchrule.yaml
+++ b/config/samples/sonarqube_v1alpha1_sonarqubebranchrule.yaml
@@ -1,0 +1,12 @@
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeBranchRule
+metadata:
+  name: my-project-main
+  namespace: default
+spec:
+  instanceRef:
+    name: my-sonarqube
+  projectKey: my-project
+  branch: main
+  newCodePeriod:
+    mode: previous_version

--- a/config/samples/sonarqube_v1alpha1_sonarqubegroup.yaml
+++ b/config/samples/sonarqube_v1alpha1_sonarqubegroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeGroup
+metadata:
+  name: my-team
+  namespace: default
+spec:
+  instanceRef:
+    name: my-sonarqube
+  name: my-team
+  description: Engineering team with project create/edit access

--- a/config/samples/sonarqube_v1alpha1_sonarqubepermissiontemplate.yaml
+++ b/config/samples/sonarqube_v1alpha1_sonarqubepermissiontemplate.yaml
@@ -1,0 +1,12 @@
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubePermissionTemplate
+metadata:
+  name: team-a
+  namespace: default
+spec:
+  instanceRef:
+    name: my-sonarqube
+  name: team-a
+  description: Default permissions for projects owned by team-a
+  projectKeyPattern: "team-a\\..*"
+  isDefault: false

--- a/config/samples/sonarqube_v1alpha1_sonarqubewebhook.yaml
+++ b/config/samples/sonarqube_v1alpha1_sonarqubewebhook.yaml
@@ -1,0 +1,13 @@
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeWebhook
+metadata:
+  name: ci-notify
+  namespace: default
+spec:
+  instanceRef:
+    name: my-sonarqube
+  name: ci-notify
+  url: https://ci.example.com/sonarqube-webhook
+  projectKey: my-project
+  secretRef:
+    name: ci-notify-hmac

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -69,6 +69,10 @@ const (
 	// reconciled). Mirrors the convention from k8s.io/apimachinery condition
 	// types.
 	conditionDegraded = "Degraded"
+	// conditionMainBranchSynced reports whether SonarQubeProject's main branch
+	// matches spec.mainBranch. Set to False with a Reason when fetch or rename
+	// fails so the failure is visible without parsing event streams.
+	conditionMainBranchSynced = "MainBranchSynced"
 
 	// phaseReady and its siblings are values for Status.Phase fields.
 	// Kept separate from conditionReady to avoid silent breakage if the condition

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -64,6 +64,11 @@ const (
 	conditionReady            = "Ready"
 	conditionAdminInitialized = "AdminInitialized"
 	conditionInstalled        = "Installed"
+	// conditionDegraded surfaces partial-functionality states that are not
+	// outright failures (e.g. scaffold-only spec fields accepted but not yet
+	// reconciled). Mirrors the convention from k8s.io/apimachinery condition
+	// types.
+	conditionDegraded = "Degraded"
 
 	// phaseReady and its siblings are values for Status.Phase fields.
 	// Kept separate from conditionReady to avoid silent breakage if the condition

--- a/internal/controller/sonarqubeinstance_controller.go
+++ b/internal/controller/sonarqubeinstance_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -89,13 +90,7 @@ func (r *SonarQubeInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	log.Info("Reconciling", "name", instance.Name, "phase", instance.Status.Phase)
 
-	if instance.Spec.Cluster != nil {
-		// Scaffold: DCE topology is recorded but the operator still renders
-		// the single-pod StatefulSet below. The follow-up will switch to
-		// two StatefulSets (app + search) when spec.cluster is set.
-		r.Recorder.Event(instance, corev1.EventTypeWarning, "DCENotImplementedYet",
-			"spec.cluster is accepted but DCE rendering is not wired up yet — see issue #11. Single-node deploy is used.")
-	}
+	r.surfaceScaffoldDegraded(instance)
 
 	if err := r.reconcileStatefulSet(ctx, instance); err != nil {
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "StatefulSetFailed", err.Error())
@@ -117,15 +112,6 @@ func (r *SonarQubeInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("reconciling Ingress: %w", err)
 	}
 
-	if instance.Spec.Monitoring.Enabled {
-		// Scaffold: the actual ServiceMonitor reconciliation has a soft
-		// dependency on monitoring.coreos.com/v1 and will land as a
-		// follow-up. We surface a Warning event so the user knows their
-		// monitoring config is recorded but not yet applied.
-		r.Recorder.Event(instance, corev1.EventTypeWarning, "MonitoringNotImplementedYet",
-			"spec.monitoring.enabled is accepted but the ServiceMonitor reconciler is not wired up yet — see issue #10")
-	}
-
 	serviceURL := instanceAPIURL(instance)
 	result := r.reconcileHealth(ctx, instance, serviceURL)
 
@@ -145,6 +131,42 @@ func (r *SonarQubeInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	return result, nil
+}
+
+// surfaceScaffoldDegraded sets a persistent Degraded condition listing the
+// scaffold-only spec fields the user has enabled. Without this, users only see
+// a fleeting Warning event at reconcile time and have no programmatic signal
+// that their config is accepted but not actually applied.
+func (r *SonarQubeInstanceReconciler) surfaceScaffoldDegraded(instance *sonarqubev1alpha1.SonarQubeInstance) {
+	var reasons []string
+	if instance.Spec.Cluster != nil {
+		reasons = append(reasons, "spec.cluster (DCE rendering not implemented — single-node deploy used)")
+		r.Recorder.Event(instance, corev1.EventTypeWarning, "DCENotImplementedYet",
+			"spec.cluster is accepted but DCE rendering is not wired up yet — see issue #11")
+	}
+	if instance.Spec.Monitoring.Enabled {
+		reasons = append(reasons, "spec.monitoring.enabled (ServiceMonitor reconciler not implemented)")
+		r.Recorder.Event(instance, corev1.EventTypeWarning, "MonitoringNotImplementedYet",
+			"spec.monitoring.enabled is accepted but the ServiceMonitor reconciler is not wired up yet — see issue #10")
+	}
+
+	if len(reasons) == 0 {
+		apimeta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:               conditionDegraded,
+			Status:             metav1.ConditionFalse,
+			Reason:             "AllFeaturesImplemented",
+			Message:            "No scaffold-only spec fields are enabled",
+			ObservedGeneration: instance.Generation,
+		})
+		return
+	}
+	apimeta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:               conditionDegraded,
+		Status:             metav1.ConditionTrue,
+		Reason:             "ScaffoldOnlyFieldsEnabled",
+		Message:            "These spec fields are accepted but not yet reconciled: " + strings.Join(reasons, "; "),
+		ObservedGeneration: instance.Generation,
+	})
 }
 
 // reconcileHealth checks SonarQube health and handles the initial startup.

--- a/internal/controller/sonarqubeproject_controller.go
+++ b/internal/controller/sonarqubeproject_controller.go
@@ -387,8 +387,10 @@ func (r *SonarQubeProjectReconciler) reconcileProjectPermissions(ctx context.Con
 }
 
 // reconcileMainBranch fetches the current main branch from SonarQube and renames it
-// if it doesn't match spec.mainBranch. Errors are non-fatal: a warning event is emitted
-// and reconciliation continues so the project doesn't get stuck in Failed.
+// if it doesn't match spec.mainBranch. Errors are non-fatal — they don't block the
+// rest of project reconciliation — but they are surfaced as a MainBranchSynced=False
+// condition so users can detect the failure programmatically rather than only via
+// transient warning events.
 func (r *SonarQubeProjectReconciler) reconcileMainBranch(ctx context.Context, project *sonarqubev1alpha1.SonarQubeProject, sonarClient sonarqube.Client) error {
 	log := logf.FromContext(ctx)
 
@@ -396,22 +398,43 @@ func (r *SonarQubeProjectReconciler) reconcileMainBranch(ctx context.Context, pr
 	if err != nil {
 		r.Recorder.Event(project, corev1.EventTypeWarning, "MainBranchFetchFailed", err.Error())
 		log.Info("Could not fetch main branch, skipping rename", "error", err.Error())
+		setMainBranchCondition(project, metav1.ConditionFalse, "FetchFailed",
+			fmt.Sprintf("Could not fetch current main branch: %s", err))
 		return nil
 	}
 
 	if current == project.Spec.MainBranch {
+		setMainBranchCondition(project, metav1.ConditionTrue, "InSync",
+			fmt.Sprintf("Main branch is %q", current))
 		return nil
 	}
 
 	if err := sonarClient.RenameMainBranch(ctx, project.Spec.Key, project.Spec.MainBranch); err != nil {
 		r.Recorder.Event(project, corev1.EventTypeWarning, "MainBranchRenameFailed", err.Error())
 		log.Info("Could not rename main branch", "from", current, "to", project.Spec.MainBranch, "error", err.Error())
+		setMainBranchCondition(project, metav1.ConditionFalse, "RenameFailed",
+			fmt.Sprintf("Could not rename main branch from %q to %q: %s", current, project.Spec.MainBranch, err))
 		return nil
 	}
 
 	r.Recorder.Event(project, corev1.EventTypeNormal, "MainBranchRenamed",
 		fmt.Sprintf("Main branch renamed from %q to %q", current, project.Spec.MainBranch))
+	setMainBranchCondition(project, metav1.ConditionTrue, "Renamed",
+		fmt.Sprintf("Main branch renamed from %q to %q", current, project.Spec.MainBranch))
 	return nil
+}
+
+// setMainBranchCondition sets the MainBranchSynced condition with the given
+// status, reason and message. ObservedGeneration is set to the project's current
+// generation so consumers can detect stale conditions.
+func setMainBranchCondition(project *sonarqubev1alpha1.SonarQubeProject, status metav1.ConditionStatus, reason, message string) {
+	apimeta.SetStatusCondition(&project.Status.Conditions, metav1.Condition{
+		Type:               conditionMainBranchSynced,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: project.Generation,
+	})
 }
 
 // reconcileCIToken ensures the CI token Secret is present and up to date.

--- a/internal/controller/sonarqubeproject_controller.go
+++ b/internal/controller/sonarqubeproject_controller.go
@@ -444,6 +444,19 @@ func (r *SonarQubeProjectReconciler) reconcileCIToken(ctx context.Context, proje
 		return nil
 	}
 
+	// Clear the rotate-token annotation BEFORE we revoke or regenerate. If this
+	// Patch fails we abort the rotation; the existing token stays valid and the
+	// next reconcile retries. Doing it the other way around (rotate first, then
+	// clear the annotation) caused token churn: an annotation Update failure
+	// re-rotated the just-created token on every retry until success.
+	if forceRotate {
+		patch := client.MergeFrom(project.DeepCopy())
+		delete(project.Annotations, AnnotationRotateToken)
+		if err := r.Patch(ctx, project, patch); err != nil {
+			return fmt.Errorf("clearing rotation annotation: %w", err)
+		}
+	}
+
 	// Revoke the old token in SonarQube (best-effort — it may not exist yet).
 	_ = sonarClient.RevokeToken(ctx, tokenName)
 
@@ -478,14 +491,6 @@ func (r *SonarQubeProjectReconciler) reconcileCIToken(ctx context.Context, proje
 	}
 	if err := r.Create(ctx, newSecret); err != nil {
 		return fmt.Errorf("creating CI token secret: %w", err)
-	}
-
-	// Remove the rotation annotation so the next reconciliation is a no-op.
-	if forceRotate {
-		delete(project.Annotations, AnnotationRotateToken)
-		if err := r.Update(ctx, project); err != nil {
-			return fmt.Errorf("removing rotation annotation: %w", err)
-		}
 	}
 
 	project.Status.TokenSecretRef = secretName

--- a/internal/controller/sonarqubeuser_controller.go
+++ b/internal/controller/sonarqubeuser_controller.go
@@ -409,11 +409,17 @@ func (r *SonarQubeUserReconciler) reconcileUserTokens(ctx context.Context, user 
 
 // reconcileUserGlobalPermissions diffs spec.globalPermissions against
 // status.managedGlobalPermissions and adds/removes only the grants the
-// operator owns.
+// operator owns. Permissions already tracked in status are skipped on the
+// add path so we don't re-grant them on every reconcile (some SonarQube
+// versions return an error when re-granting an existing permission).
 func (r *SonarQubeUserReconciler) reconcileUserGlobalPermissions(ctx context.Context, user *sonarqubev1alpha1.SonarQubeUser, sonarClient sonarqube.Client) error {
 	desired := make(map[string]bool, len(user.Spec.GlobalPermissions))
 	for _, p := range user.Spec.GlobalPermissions {
 		desired[p] = true
+	}
+	managed := make(map[string]bool, len(user.Status.ManagedGlobalPermissions))
+	for _, p := range user.Status.ManagedGlobalPermissions {
+		managed[p] = true
 	}
 
 	for _, p := range user.Status.ManagedGlobalPermissions {
@@ -426,6 +432,9 @@ func (r *SonarQubeUserReconciler) reconcileUserGlobalPermissions(ctx context.Con
 	}
 
 	for _, p := range user.Spec.GlobalPermissions {
+		if managed[p] {
+			continue
+		}
 		if err := sonarClient.AddUserGlobalPermission(ctx, user.Spec.Login, p); err != nil {
 			return fmt.Errorf("granting global permission %q: %w", p, err)
 		}
@@ -444,6 +453,10 @@ func (r *SonarQubeUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			),
 		}).
 		For(&sonarqubev1alpha1.SonarQubeUser{}).
+		// Owns the user-token Secrets created by reconcileUserTokens. Without
+		// this, manually deleting a token Secret to force regeneration only
+		// takes effect at the next periodic resync (default 10h).
+		Owns(&corev1.Secret{}).
 		Named("sonarqubeuser").
 		Complete(r)
 }

--- a/internal/controller/sonarqubeuser_controller_test.go
+++ b/internal/controller/sonarqubeuser_controller_test.go
@@ -348,7 +348,8 @@ var _ = Describe("SonarQubeUser Controller", func() {
 		u.Spec.GlobalPermissions = []string{"admin", "scan"}
 		Expect(k8sClient.Create(ctx, u)).To(Succeed())
 
-		// Status: previously managed "profileadmin" → must be revoked.
+		// Status: "admin" was previously managed (so must NOT be re-granted),
+		// "profileadmin" was previously managed (so must be revoked).
 		updated := &sonarqubev1alpha1.SonarQubeUser{}
 		Expect(k8sClient.Get(ctx, nn, updated)).To(Succeed())
 		updated.Status.ManagedGlobalPermissions = []string{"admin", "profileadmin"}
@@ -360,8 +361,11 @@ var _ = Describe("SonarQubeUser Controller", func() {
 		_, err := newUserReconciler(mock).Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(mock.addUserGlobalPermCalls).To(Equal(2))
-		Expect(mock.addedGlobalPerms).To(ContainElements("eve:admin", "eve:scan"))
+		// Only "scan" is new (not in managed set), so only one add call is expected.
+		// "admin" is already tracked as managed, re-granting it would error on
+		// some SonarQube versions and adds noise on every reconcile.
+		Expect(mock.addUserGlobalPermCalls).To(Equal(1))
+		Expect(mock.addedGlobalPerms).To(Equal([]string{"eve:scan"}))
 		Expect(mock.removeUserGlobalPermCalls).To(Equal(1))
 		Expect(mock.removedGlobalPerms).To(Equal([]string{"eve:profileadmin"}))
 


### PR DESCRIPTION
## Summary

Bundle of release-blocker and hardening fixes from a code review of the
operator ahead of `v0.5.0` stable. Each commit is independent and can be
reverted in isolation if needed.

### P0 — release-blockers

- **`fix(packaging)`** — `install.yaml` and the Helm chart only shipped 4–5 of the 10 CRDs:
  - `config/crd/kustomization.yaml` only listed Instance/Plugin/Project/QualityGate, so `make build-installer` produced a `dist/install.yaml` missing User/Group/PermissionTemplate/Webhook/BranchRule/Backup.
  - The chart's hand-written `clusterrole.yaml` granted RBAC for only those same 5 CRDs (and lacked `batch/cronjobs` for the Backup controller). Helm-installed operators couldn't reconcile half of the advertised CRDs.
  - `aggregated-roles.yaml` and the `artifacthub.io/crds` annotation lagged the same way.
  - `config/samples/kustomization.yaml` only referenced 5 samples — the 5 missing sample files have been added.

### P1 — explicitly listed in the ROADMAP

- **`fix(manager,chart)`** — wire `--webhook-port` through `webhook.Options.Port`. The chart's `Values.webhook.port` only changed cosmetic ports; controller-runtime stayed on its 9443 default. Now the chart passes the value as an arg.
- **`fix(project)`** — clear the `rotate-token` annotation **before** revoking/regenerating the CI token. An `Update` failure used to re-rotate the just-created token on every retry until success.

### Hardening

- **`fix(user)`** — declare `Owns(&corev1.Secret{})` so deleting a token Secret triggers a reconcile, and skip the add path for global permissions already tracked in `status.managedGlobalPermissions` (some SonarQube versions error on re-grant).
- **`fix(instance)`** — surface a persistent `Degraded` condition listing scaffold-only spec fields (`spec.cluster`, `spec.monitoring.enabled`) instead of only emitting a fleeting Warning event.
- **`fix(project)`** — propagate main-branch fetch/rename failures via a `MainBranchSynced` condition so they aren't lost in event noise.
- **`fix(manager)`** — default `zap.Options.Development=false` so production logs are JSON; `--zap-devel` re-enables console output for `make run`.

### Test alignment

- **`test(user)`** — update the global-permissions assertion to match the new diff-based reconcile (no re-grants for already-managed permissions).

## Test plan

- [ ] `make manifests generate fmt vet lint test` passes in CI (lint/test workflows)
- [ ] `make test-e2e` passes in CI (Kind smoke)
- [ ] `helm lint charts/sonarqube-operator` passes (unit / RBAC)
- [ ] Manual: `helm template charts/sonarqube-operator | kubectl apply --dry-run=server -f -` accepts the manifests
- [ ] Manual: `make build-installer IMG=test:latest` produces a `dist/install.yaml` containing all 10 CRDs and ClusterRole rules covering them
- [ ] Manual: deploy with `webhook.enabled=true` and a non-default `webhook.port` (e.g. 8443) — verify admission still works
- [ ] Manual: trigger a CI-token rotation, confirm the new token is durable across operator restart and the annotation is cleared