### PR TITLE
ci: scan against the operator-managed SonarQube on every PR and main …

### DIFF
--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -1,0 +1,62 @@
+name: SonarQube Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Skip on PRs from forks: SONAR_TOKEN is not exposed to fork-triggered runs,
+# so the scan would fail with a confusing 401. Maintainers can re-trigger via
+# a same-repo branch if they need a fork PR scanned.
+jobs:
+  preflight:
+    name: Check secrets are set
+    runs-on: ubuntu-latest
+    outputs:
+      can_scan: ${{ steps.check.outputs.can_scan }}
+    steps:
+      - id: check
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+        run: |
+          if [ -n "$SONAR_TOKEN" ] && [ -n "$SONAR_HOST_URL" ]; then
+            echo "can_scan=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::SONAR_TOKEN secret or SONAR_HOST_URL variable missing — skipping scan"
+            echo "can_scan=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  scan:
+    name: Scan and wait for Quality Gate
+    needs: preflight
+    if: needs.preflight.outputs.can_scan == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Sonar PR analysis needs the full history to compute "new code"
+          # against the target branch.
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run unit tests with coverage
+        run: |
+          go mod tidy
+          make test
+
+      - name: SonarQube scan
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+        with:
+          args: >
+            -Dsonar.qualitygate.wait=true
+            -Dsonar.qualitygate.timeout=300

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,17 @@
+sonar.projectKey=sonarqube-operator
+sonar.projectName=SonarQube Operator
+
+# Source layout — Go module rooted at the repo top
+sonar.sources=api,cmd,internal
+sonar.tests=api,cmd,internal
+sonar.test.inclusions=**/*_test.go
+
+# Skip generated and vendored code
+sonar.exclusions=**/zz_generated.*.go,**/mock_*.go
+sonar.coverage.exclusions=**/zz_generated.*.go,**/*_test.go,test/**
+
+# go test -coverprofile=cover.out output (produced by `make test`)
+sonar.go.coverage.reportPaths=cover.out
+
+# Encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary                         
                                                    
  - New CI workflow that scans the operator's own Go code on every PR + push to `main` against the SonarQube the operator itself deploys (dogfooding via
  [sonarqube-operator-gitops-example](https://github.com/BEIRDINH0S/sonarqube-operator-gitops-example))
  - Quality Gate result blocks the workflow on regression (`qualitygate.wait=true`)                                                                                            - Fork-safe: preflight job skips the scan with a clear warning when secrets are not exposed
                                                                                                                                                                             
  ## Changes                             

  - `sonar-project.properties` — project key `sonarqube-operator`, sources `api/cmd/internal`, excludes `zz_generated.*.go` and tests from coverage, reads `cover.out`       
  produced by `make test`
  - `.github/workflows/sonar-analysis.yml` — preflight + scan jobs using `SonarSource/sonarqube-scan-action@v4`

  ## Test plan

  - [ ] `go build ./...`
  - [ ] `go vet ./...`
  - [ ] First run on a PR with `SONAR_TOKEN` + `SONAR_HOST_URL` set: scan completes, Quality Gate result visible
  - [ ] First run on a PR from a fork (no secret): preflight skips with a warning, no failure
  - [ ] Regression check: drop coverage deliberately, confirm the workflow fails on the QG wait

  ## Related issues

  (none — paves the way for #49 by enforcing coverage thresholds via SonarQube QG instead of a Makefile threshold)

  ## Notes for the reviewer

  Wiring (one-time, after merge):
  1. Apply [sonarqube-operator-gitops-example PR #2](https://github.com/BEIRDINH0S/sonarqube-operator-gitops-example/pull/2) on the cluster — creates the
  `sonarqube-operator` project + the `sonarqube-operator-ci-token` Secret
  2. Extract: `kubectl get secret sonarqube-operator-ci-token -n sonarqube -o jsonpath='{.data.token}' | base64 -d`
  3. Repo **secret** `SONAR_TOKEN` ← value from step 2
  4. Repo **variable** `SONAR_HOST_URL` ← public URL of the homelab SonarQube