### PR TITLE
feat: enforce same-namespace InstanceRef with opt-in cross-namespace allowlist (closes #45)

### DIFF
--- a/api/v1alpha1/cross_namespace_validator.go
+++ b/api/v1alpha1/cross_namespace_validator.go
@@ -70,7 +70,7 @@ func ValidateInstanceRefNamespace(ctx context.Context, k8sClient client.Client, 
 	if allowed == "*" {
 		return nil
 	}
-	for _, entry := range strings.Split(allowed, ",") {
+	for entry := range strings.SplitSeq(allowed, ",") {
 		if strings.TrimSpace(entry) == callerNamespace {
 			return nil
 		}

--- a/api/v1alpha1/cross_namespace_validator.go
+++ b/api/v1alpha1/cross_namespace_validator.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CrossNamespaceOptInAnnotation is the annotation a SonarQubeInstance carries
+// to opt into cross-namespace InstanceRefs. The value is a comma-separated
+// list of namespace names allowed to point at this instance, or "*" to allow
+// any namespace. Empty / missing annotation = same-namespace only.
+//
+// Example:
+//
+//	apiVersion: sonarqube.sonarqube.io/v1alpha1
+//	kind: SonarQubeInstance
+//	metadata:
+//	  name: shared
+//	  namespace: sonarqube
+//	  annotations:
+//	    sonarqube.io/cross-namespace-from: "team-a,team-b"
+const CrossNamespaceOptInAnnotation = "sonarqube.io/cross-namespace-from"
+
+// ValidateInstanceRefNamespace enforces the cross-namespace policy on an
+// InstanceRef. It is the shared admission check used by every CR webhook
+// that carries a spec.instanceRef.
+//
+// Rules:
+//   - If instanceRef.Namespace is empty or equals callerNamespace: always allow.
+//   - Otherwise the target SonarQubeInstance must carry the
+//     CrossNamespaceOptInAnnotation listing callerNamespace (or "*").
+//   - If the target Instance does not exist or the lookup fails, the request
+//     is rejected — fail closed, the controller's reconcile-time logic will
+//     surface the genuine missing-instance case clearly via Status.
+func ValidateInstanceRefNamespace(ctx context.Context, k8sClient client.Client, callerNamespace string, ref InstanceRef) error {
+	targetNS := ref.Namespace
+	if targetNS == "" || targetNS == callerNamespace {
+		return nil
+	}
+
+	instance := &SonarQubeInstance{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: targetNS}, instance); err != nil {
+		return fmt.Errorf("cross-namespace instanceRef rejected: cannot verify target SonarQubeInstance %q in namespace %q: %w", ref.Name, targetNS, err)
+	}
+
+	allowed := strings.TrimSpace(instance.Annotations[CrossNamespaceOptInAnnotation])
+	if allowed == "" {
+		return fmt.Errorf("cross-namespace instanceRef rejected: SonarQubeInstance %q in namespace %q does not carry the %q annotation — see docs/operations/multi-tenancy.md", ref.Name, targetNS, CrossNamespaceOptInAnnotation)
+	}
+	if allowed == "*" {
+		return nil
+	}
+	for _, entry := range strings.Split(allowed, ",") {
+		if strings.TrimSpace(entry) == callerNamespace {
+			return nil
+		}
+	}
+	return fmt.Errorf("cross-namespace instanceRef rejected: namespace %q is not in the allowlist %q on SonarQubeInstance %q/%q", callerNamespace, allowed, targetNS, ref.Name)
+}

--- a/api/v1alpha1/cross_namespace_validator_test.go
+++ b/api/v1alpha1/cross_namespace_validator_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestValidateInstanceRefNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := AddToScheme(scheme); err != nil {
+		t.Fatalf("registering scheme: %v", err)
+	}
+
+	makeInstance := func(ns, name, annotation string) *SonarQubeInstance {
+		obj := &SonarQubeInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		}
+		if annotation != "" {
+			obj.Annotations = map[string]string{CrossNamespaceOptInAnnotation: annotation}
+		}
+		return obj
+	}
+
+	cases := []struct {
+		name          string
+		callerNS      string
+		ref           InstanceRef
+		instances     []runtime.Object
+		wantErr       bool
+		wantErrSubstr string
+	}{
+		{
+			name:     "empty namespace defaults to caller — allowed",
+			callerNS: "team-a",
+			ref:      InstanceRef{Name: "sq", Namespace: ""},
+			wantErr:  false,
+		},
+		{
+			name:     "same-namespace ref — allowed",
+			callerNS: "team-a",
+			ref:      InstanceRef{Name: "sq", Namespace: "team-a"},
+			wantErr:  false,
+		},
+		{
+			name:          "cross-ns, target instance missing — rejected",
+			callerNS:      "team-a",
+			ref:           InstanceRef{Name: "sq", Namespace: "shared"},
+			instances:     nil,
+			wantErr:       true,
+			wantErrSubstr: "cannot verify target SonarQubeInstance",
+		},
+		{
+			name:          "cross-ns, no annotation — rejected",
+			callerNS:      "team-a",
+			ref:           InstanceRef{Name: "sq", Namespace: "shared"},
+			instances:     []runtime.Object{makeInstance("shared", "sq", "")},
+			wantErr:       true,
+			wantErrSubstr: "does not carry the",
+		},
+		{
+			name:      "cross-ns, annotation lists caller — allowed",
+			callerNS:  "team-a",
+			ref:       InstanceRef{Name: "sq", Namespace: "shared"},
+			instances: []runtime.Object{makeInstance("shared", "sq", "team-a,team-b")},
+			wantErr:   false,
+		},
+		{
+			name:      "cross-ns, annotation has whitespace around entries — allowed",
+			callerNS:  "team-a",
+			ref:       InstanceRef{Name: "sq", Namespace: "shared"},
+			instances: []runtime.Object{makeInstance("shared", "sq", "  team-a , team-b  ")},
+			wantErr:   false,
+		},
+		{
+			name:          "cross-ns, annotation excludes caller — rejected",
+			callerNS:      "team-c",
+			ref:           InstanceRef{Name: "sq", Namespace: "shared"},
+			instances:     []runtime.Object{makeInstance("shared", "sq", "team-a,team-b")},
+			wantErr:       true,
+			wantErrSubstr: "is not in the allowlist",
+		},
+		{
+			name:      "cross-ns, wildcard annotation — allowed",
+			callerNS:  "team-z",
+			ref:       InstanceRef{Name: "sq", Namespace: "shared"},
+			instances: []runtime.Object{makeInstance("shared", "sq", "*")},
+			wantErr:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.instances...).Build()
+			err := ValidateInstanceRefNamespace(context.Background(), c, tc.callerNS, tc.ref)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tc.wantErrSubstr != "" && (err == nil || !strings.Contains(err.Error(), tc.wantErrSubstr)) {
+				t.Fatalf("expected error to contain %q, got %v", tc.wantErrSubstr, err)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/instanceref_webhook.go
+++ b/api/v1alpha1/instanceref_webhook.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:path=/validate-sonarqube-sonarqube-io-v1alpha1-sonarqubeproject,mutating=false,failurePolicy=ignore,sideEffects=None,groups=sonarqube.sonarqube.io,resources=sonarqubeprojects,verbs=create;update,versions=v1alpha1,name=vsonarqubeproject.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-sonarqube-sonarqube-io-v1alpha1-sonarqubeuser,mutating=false,failurePolicy=ignore,sideEffects=None,groups=sonarqube.sonarqube.io,resources=sonarqubeusers,verbs=create;update,versions=v1alpha1,name=vsonarqubeuser.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-sonarqube-sonarqube-io-v1alpha1-sonarqubeplugin,mutating=false,failurePolicy=ignore,sideEffects=None,groups=sonarqube.sonarqube.io,resources=sonarqubeplugins,verbs=create;update,versions=v1alpha1,name=vsonarqubeplugin.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-sonarqube-sonarqube-io-v1alpha1-sonarqubequalitygate,mutating=false,failurePolicy=ignore,sideEffects=None,groups=sonarqube.sonarqube.io,resources=sonarqubequalitygates,verbs=create;update,versions=v1alpha1,name=vsonarqubequalitygate.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-sonarqube-sonarqube-io-v1alpha1-sonarqubegroup,mutating=false,failurePolicy=ignore,sideEffects=None,groups=sonarqube.sonarqube.io,resources=sonarqubegroups,verbs=create;update,versions=v1alpha1,name=vsonarqubegroup.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-sonarqube-sonarqube-io-v1alpha1-sonarqubepermissiontemplate,mutating=false,failurePolicy=ignore,sideEffects=None,groups=sonarqube.sonarqube.io,resources=sonarqubepermissiontemplates,verbs=create;update,versions=v1alpha1,name=vsonarqubepermissiontemplate.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-sonarqube-sonarqube-io-v1alpha1-sonarqubewebhook,mutating=false,failurePolicy=ignore,sideEffects=None,groups=sonarqube.sonarqube.io,resources=sonarqubewebhooks,verbs=create;update,versions=v1alpha1,name=vsonarqubewebhook.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-sonarqube-sonarqube-io-v1alpha1-sonarqubebranchrule,mutating=false,failurePolicy=ignore,sideEffects=None,groups=sonarqube.sonarqube.io,resources=sonarqubebranchrules,verbs=create;update,versions=v1alpha1,name=vsonarqubebranchrule.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-sonarqube-sonarqube-io-v1alpha1-sonarqubebackup,mutating=false,failurePolicy=ignore,sideEffects=None,groups=sonarqube.sonarqube.io,resources=sonarqubebackups,verbs=create;update,versions=v1alpha1,name=vsonarqubebackup.kb.io,admissionReviewVersions=v1
+
+// instanceRefExtractor returns the caller namespace and the spec.instanceRef
+// of a CR so the shared validator can be wired generically without one
+// validator type per CR.
+type instanceRefExtractor[T client.Object] func(obj T) (namespace string, ref InstanceRef)
+
+// genericInstanceRefValidator is a typed wrapper around
+// ValidateInstanceRefNamespace. One instance per CR type is built in
+// SetupInstanceRefWebhooks via Go generics so the cross-namespace gate is
+// expressed exactly once.
+type genericInstanceRefValidator[T client.Object] struct {
+	client    client.Client
+	extractor instanceRefExtractor[T]
+}
+
+func (v *genericInstanceRefValidator[T]) ValidateCreate(ctx context.Context, obj T) (admission.Warnings, error) {
+	ns, ref := v.extractor(obj)
+	return nil, ValidateInstanceRefNamespace(ctx, v.client, ns, ref)
+}
+
+func (v *genericInstanceRefValidator[T]) ValidateUpdate(ctx context.Context, _, newObj T) (admission.Warnings, error) {
+	ns, ref := v.extractor(newObj)
+	return nil, ValidateInstanceRefNamespace(ctx, v.client, ns, ref)
+}
+
+func (v *genericInstanceRefValidator[T]) ValidateDelete(_ context.Context, _ T) (admission.Warnings, error) {
+	// Delete is a no-op — once the CR exists, removing it must always succeed
+	// regardless of the cross-namespace policy.
+	return nil, nil
+}
+
+func setupRefWebhook[T client.Object](mgr ctrl.Manager, obj T, extractor instanceRefExtractor[T]) error {
+	v := &genericInstanceRefValidator[T]{client: mgr.GetClient(), extractor: extractor}
+	if err := ctrl.NewWebhookManagedBy(mgr, obj).WithValidator(v).Complete(); err != nil {
+		return fmt.Errorf("setting up instanceRef webhook for %T: %w", obj, err)
+	}
+	return nil
+}
+
+// SetupInstanceRefWebhooks registers the cross-namespace validator with the
+// manager for every CR type that carries a spec.instanceRef. Designed to be
+// called from cmd/main.go behind the same --enable-webhook gate as the
+// existing SonarQubeInstance webhook so a deployment that does not run the
+// webhook server pays no extra cost.
+func SetupInstanceRefWebhooks(mgr ctrl.Manager) error {
+	if err := setupRefWebhook(mgr, &SonarQubeProject{}, func(o *SonarQubeProject) (string, InstanceRef) {
+		return o.Namespace, o.Spec.InstanceRef
+	}); err != nil {
+		return err
+	}
+	if err := setupRefWebhook(mgr, &SonarQubeUser{}, func(o *SonarQubeUser) (string, InstanceRef) {
+		return o.Namespace, o.Spec.InstanceRef
+	}); err != nil {
+		return err
+	}
+	if err := setupRefWebhook(mgr, &SonarQubePlugin{}, func(o *SonarQubePlugin) (string, InstanceRef) {
+		return o.Namespace, o.Spec.InstanceRef
+	}); err != nil {
+		return err
+	}
+	if err := setupRefWebhook(mgr, &SonarQubeQualityGate{}, func(o *SonarQubeQualityGate) (string, InstanceRef) {
+		return o.Namespace, o.Spec.InstanceRef
+	}); err != nil {
+		return err
+	}
+	if err := setupRefWebhook(mgr, &SonarQubeGroup{}, func(o *SonarQubeGroup) (string, InstanceRef) {
+		return o.Namespace, o.Spec.InstanceRef
+	}); err != nil {
+		return err
+	}
+	if err := setupRefWebhook(mgr, &SonarQubePermissionTemplate{}, func(o *SonarQubePermissionTemplate) (string, InstanceRef) {
+		return o.Namespace, o.Spec.InstanceRef
+	}); err != nil {
+		return err
+	}
+	if err := setupRefWebhook(mgr, &SonarQubeWebhook{}, func(o *SonarQubeWebhook) (string, InstanceRef) {
+		return o.Namespace, o.Spec.InstanceRef
+	}); err != nil {
+		return err
+	}
+	if err := setupRefWebhook(mgr, &SonarQubeBranchRule{}, func(o *SonarQubeBranchRule) (string, InstanceRef) {
+		return o.Namespace, o.Spec.InstanceRef
+	}); err != nil {
+		return err
+	}
+	if err := setupRefWebhook(mgr, &SonarQubeBackup{}, func(o *SonarQubeBackup) (string, InstanceRef) {
+		return o.Namespace, o.Spec.InstanceRef
+	}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/charts/sonarqube-operator/templates/webhook.yaml
+++ b/charts/sonarqube-operator/templates/webhook.yaml
@@ -44,4 +44,30 @@ webhooks:
         apiVersions: [v1alpha1]
         operations: [CREATE, UPDATE]
         resources: [sonarqubeinstances]
+{{/*
+Cross-namespace InstanceRef gate. One webhook per CR that carries
+spec.instanceRef. The handler is the same shared validator on the manager
+side; the per-resource entry here is what the API server uses to route
+admission calls. Same TLS / failurePolicy as the instance webhook.
+*/}}
+{{- $kinds := list "sonarqubeproject" "sonarqubeuser" "sonarqubeplugin" "sonarqubequalitygate" "sonarqubegroup" "sonarqubepermissiontemplate" "sonarqubewebhook" "sonarqubebranchrule" "sonarqubebackup" -}}
+{{- range $kind := $kinds }}
+  - name: v{{ $kind }}.kb.io
+    admissionReviewVersions: [v1]
+    sideEffects: None
+    failurePolicy: {{ $.Values.webhook.failurePolicy }}
+    clientConfig:
+      service:
+        name: {{ include "sonarqube-operator.webhookServiceName" $ }}
+        namespace: {{ $.Release.Namespace }}
+        path: /validate-sonarqube-sonarqube-io-v1alpha1-{{ $kind }}
+      {{- if and (not $.Values.webhook.certManager.enabled) $.Values.webhook.caBundle }}
+      caBundle: {{ $.Values.webhook.caBundle }}
+      {{- end }}
+    rules:
+      - apiGroups: [sonarqube.sonarqube.io]
+        apiVersions: [v1alpha1]
+        operations: [CREATE, UPDATE]
+        resources: [{{ $kind }}s]
+{{- end }}
 {{- end }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -299,6 +299,10 @@ func main() {
 			setupLog.Error(err, "Failed to create webhook", "webhook", "SonarQubeInstance")
 			os.Exit(1)
 		}
+		if err := sonarqubev1alpha1.SetupInstanceRefWebhooks(mgr); err != nil {
+			setupLog.Error(err, "Failed to create instanceRef webhooks")
+			os.Exit(1)
+		}
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/docs/operations/multi-tenancy.md
+++ b/docs/operations/multi-tenancy.md
@@ -1,0 +1,114 @@
+# Multi-tenancy
+
+This page describes the trust boundary the operator enforces between
+namespaces, the attack it mitigates, and how to opt into wider sharing
+when you actually need it.
+
+## TL;DR
+
+- Every CR with a `spec.instanceRef` (Project, User, Plugin, QualityGate,
+  Group, PermissionTemplate, Webhook, BranchRule, Backup) is expected to
+  live in the **same namespace as its target SonarQubeInstance**.
+- Cross-namespace `instanceRef` is rejected at admission when the
+  validating webhook is enabled (`webhook.enabled=true` in the chart).
+- To opt in, annotate the **target Instance** with the list of namespaces
+  allowed to point at it (`*` for any).
+
+## The attack the gate mitigates
+
+Without the gate, the operator's `secrets` permission is cluster-wide
+(it has to be — it manages the admin token Secret and CI token Secrets
+across the namespaces where Instances live). That means a tenant who
+can create CRs in their own namespace can craft a `SonarQubeProject`
+pointing at *another tenant's* Instance and the operator will:
+
+1. Read the victim's admin token Secret (`Status.AdminTokenSecretRef`).
+2. Use it to create a project in the victim's SonarQube.
+3. Expose a CI token Secret for that project — owned by the attacker's
+   CR — back into the attacker's namespace.
+
+Step 3 is the bad outcome: the attacker now holds a token valid against
+the victim's SonarQube. Even read-only project tokens leak project
+metadata that may be sensitive.
+
+## The gate
+
+When the validating webhook is enabled, every Create / Update on the
+9 CRs above runs through the same admission check:
+
+```
+if instanceRef.namespace == "" or instanceRef.namespace == cr.namespace:
+    allow
+else:
+    fetch the target SonarQubeInstance
+    read its `sonarqube.io/cross-namespace-from` annotation
+    allow only if the caller's namespace is in the comma-separated list
+    (or the annotation value is `*`)
+```
+
+The gate fails closed: if the target Instance does not exist or the
+lookup fails, the request is rejected with a clear error pointing to
+this page. The reconcile-time logic still surfaces the genuine
+missing-instance case via `Status.Conditions[Ready].reason=InstanceNotFound`.
+
+## Opting in
+
+Annotate the **target Instance**, not the consuming CR. That way the
+opt-in is a deliberate decision by whoever owns the Instance.
+
+```yaml
+apiVersion: sonarqube.sonarqube.io/v1alpha1
+kind: SonarQubeInstance
+metadata:
+  name: shared
+  namespace: sonarqube-shared
+  annotations:
+    # Comma-separated list of namespaces. Use "*" to allow any.
+    sonarqube.io/cross-namespace-from: "team-a,team-b"
+spec:
+  ...
+```
+
+A `SonarQubeProject` in `team-a` can now declare:
+
+```yaml
+spec:
+  instanceRef:
+    name: shared
+    namespace: sonarqube-shared
+  ...
+```
+
+A `SonarQubeProject` in `team-c` would still be rejected.
+
+## Recommended deployment patterns
+
+**Single-tenant** (default). One Instance per namespace, every consuming
+CR lives in the same namespace. No annotation, no cross-ns calls. This
+is what `kubectl apply -k config/samples/` produces.
+
+**Shared instance, named tenants**. One Instance in a `sonarqube-shared`
+namespace, tenant CRs in `team-a`, `team-b`, ... The Instance carries
+the explicit allowlist annotation. Recommended when teams share a
+SonarQube server but you still want to know exactly who can talk to it.
+
+**Shared instance, free-for-all**. Annotation value `*`. Equivalent to
+the pre-gate behavior. Use only when every namespace in the cluster is
+trusted equally — typically a single-tenant cluster.
+
+**One operator per tenant namespace**. The operator can be installed
+multiple times in scoped namespaces (`--watch-namespace=team-a` in a
+future release; for now, one Helm release per namespace works). This
+is the strongest isolation but adds operational overhead — consider it
+for hard regulatory boundaries only.
+
+## What the gate does *not* protect against
+
+- A tenant who can already `get secrets` cross-namespace via their own
+  RBAC. The gate only stops the operator from being a confused deputy;
+  it doesn't substitute for RBAC.
+- An Instance owner who annotates `*` and forgets. Treat the annotation
+  like a public bucket policy: explicit list > wildcard.
+- Compromise of the operator pod itself. Standard operator hardening
+  applies — read-only rootfs, no host mounts, runAsNonRoot, etc., all of
+  which the chart enables by default.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
   - Operations:
       - operations/index.md
       - Monitoring: operations/monitoring.md
+      - Multi-tenancy: operations/multi-tenancy.md
       - Upgrade: operations/upgrade.md
       - Troubleshooting: operations/troubleshooting.md
   - Architecture: architecture.md


### PR DESCRIPTION
## Summary

- One shared admission check (\`ValidateInstanceRefNamespace\`) wired into every CR with a \`spec.instanceRef\` (Project, User, Plugin, QualityGate, Group, PermissionTemplate, Webhook, BranchRule, Backup) via a generic typed validator
- Same-namespace refs (or empty namespace) always allowed; cross-namespace rejected unless the **target** Instance carries an opt-in annotation listing the caller's namespace (or \`*\`)
- Helm \`webhook.enabled=true\` already gates the whole webhook server, the new validators ride on the same flag
- New doc \`docs/operations/multi-tenancy.md\` covers the threat model, the attack mitigated, the opt-in flow, and three recommended deployment patterns

## Changes

- \`api/v1alpha1/cross_namespace_validator.go\` — shared helper, annotation constant, fail-closed semantics
- \`api/v1alpha1/instanceref_webhook.go\` — generic typed validator + \`SetupInstanceRefWebhooks\` registers all 9 webhooks
- \`api/v1alpha1/cross_namespace_validator_test.go\` — 8 cases (same-ns, empty, missing instance, no annotation, listed, whitespace-tolerant, excluded, wildcard)
- \`cmd/main.go\` — call \`SetupInstanceRefWebhooks\` behind \`--enable-webhook\`
- \`charts/sonarqube-operator/templates/webhook.yaml\` — 9 new entries in the \`ValidatingWebhookConfiguration\`, looped via Helm
- \`docs/operations/multi-tenancy.md\` + \`mkdocs.yml\` nav entry

## Threat addressed

Without this gate the operator's cluster-wide \`secrets\` permission lets a tenant who can create CRs in their own namespace point a \`SonarQubeProject\` at a victim's Instance and get a CI token Secret materialised in their own namespace. The gate fails closed: missing target Instance or missing annotation = rejected.

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\` green
- [x] Unit tests on the validator: 8/8 pass
- [x] Controller suite: 96/96 specs pass (the AfterSuite Windows envtest teardown error is unrelated)
- [ ] CI green (lint + tests + e2e) on this PR
- [ ] Manual: deploy with \`webhook.enabled=true\`, attempt cross-ns ref without annotation → rejected; add annotation → accepted

## Related issues

Closes #45