### PR TITLE
ci: enforce a 60% test-coverage floor (closes #49)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,17 @@ jobs:
         run: |
           go mod tidy
           make test
+
+      - name: Check coverage threshold
+        run: make check-coverage
+
+      - name: Annotate workflow summary with coverage
+        if: always()
+        run: |
+          if [ -f cover.out ]; then
+            grep -vE '/zz_generated|cmd/main\.go|test/utils' cover.out > cover.filtered.out
+            total=$(go tool cover -func=cover.filtered.out | awk '/^total/ { sub("%","",$3); print $3 }')
+            echo "## Coverage: ${total}%" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Threshold: 60% (set via COVERAGE_THRESHOLD in the Makefile)" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,33 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet setup-envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
+# Minimum total coverage that `make check-coverage` enforces. Computed
+# against cover.out with auto-generated DeepCopy, the cmd/ entrypoint, and
+# test helpers excluded — these are the same exclusions
+# sonar-project.properties uses, so the local gate stays in sync with
+# whatever the CI scanner reports. Bump this when actual coverage rises so
+# regressions are caught.
+COVERAGE_THRESHOLD ?= 60
+
+.PHONY: check-coverage
+check-coverage: ## Fail when total coverage of cover.out drops below COVERAGE_THRESHOLD. Run `make test` first.
+	@if [ ! -f cover.out ]; then \
+		echo "::error::cover.out not found — run \`make test\` first"; \
+		exit 1; \
+	fi
+	@grep -vE '/zz_generated|cmd/main\.go|test/utils' cover.out > cover.filtered.out
+	@total=$$(go tool cover -func=cover.filtered.out | awk '/^total/ { sub("%","",$$3); print $$3 }'); \
+		echo "Coverage: $${total}% (threshold $(COVERAGE_THRESHOLD)%)"; \
+		awk -v t="$$total" -v th="$(COVERAGE_THRESHOLD)" 'BEGIN { exit (t+0 < th+0) }' || { \
+			echo "::error::coverage $${total}% is below threshold $(COVERAGE_THRESHOLD)%"; \
+			rm -f cover.filtered.out; \
+			exit 1; \
+		}
+	@rm -f cover.filtered.out
+
+.PHONY: coverage
+coverage: test check-coverage ## Convenience: run tests then check the threshold.
+
 # E2E setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
 # CertManager is installed by default; skip with CERT_MANAGER_INSTALL_SKIP=true.
 KIND_CLUSTER ?= sonarqube-operator-test-e2e


### PR DESCRIPTION
## Summary

- New \`make check-coverage\` target reads \`cover.out\`, filters out generated DeepCopy / cmd / test-utils (same exclusions as \`sonar-project.properties\`), fails when total < \`COVERAGE_THRESHOLD\`
- New \`make coverage\` convenience target chains \`test\` + \`check-coverage\` for local runs
- Tests workflow gains a \`Check coverage threshold\` step plus a summary annotation that surfaces the % on every run

## Calibration

Baseline measured on \`main\` after the multi-tenancy PR: **61.6%** (filtered).
Threshold set to **60%** — 1.6-point margin so a single test removal does not flip CI red on a borderline PR. Bump as real coverage rises.

Per-package today (informational):
- \`internal/metrics\` 100%
- \`internal/controller\` 61.8%
- \`internal/sonarqube\` 31.7%
- \`api/v1alpha1\` 11.5% raw → much higher when \`zz_generated.*.go\` is excluded

## Changes

- \`Makefile\` — new \`COVERAGE_THRESHOLD\` (default 60), \`check-coverage\` and \`coverage\` targets
- \`.github/workflows/test.yml\` — call \`make check-coverage\` after \`make test\`, add summary annotation

## Test plan

- [x] \`make check-coverage\` locally prints \"Coverage: 61.6% (threshold 60%)\" and exits 0
- [x] Manual: temporarily bump \`COVERAGE_THRESHOLD\` to 65 → fails with the expected \`::error::\` annotation
- [ ] CI green on this PR

## Related issues

Closes #49