### PR TITLE
feat(rbac): opt-in namespaced mode (closes #48)

### DIFF
--- a/charts/sonarqube-operator/templates/clusterrole.yaml
+++ b/charts/sonarqube-operator/templates/clusterrole.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.rbac.create -}}
+{{- if and (eq .Values.rbac.scope "namespaced") (empty .Values.rbac.watchNamespaces) -}}
+{{- fail "rbac.scope is 'namespaced' but rbac.watchNamespaces is empty — set the namespaces the operator should reconcile in." -}}
+{{- end -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -10,6 +13,7 @@ rules:
     resources:
       - events
     verbs: [create, patch]
+{{- if eq .Values.rbac.scope "cluster" }}
   - apiGroups: [""]
     resources:
       - persistentvolumeclaims
@@ -28,6 +32,7 @@ rules:
     resources:
       - ingresses
     verbs: [create, delete, get, list, patch, update, watch]
+{{- end }}
   - apiGroups: [sonarqube.sonarqube.io]
     resources:
       - sonarqubebackups

--- a/charts/sonarqube-operator/templates/deployment.yaml
+++ b/charts/sonarqube-operator/templates/deployment.yaml
@@ -59,6 +59,11 @@ spec:
             - --webhook-port={{ .Values.webhook.port }}
             - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
             {{- end }}
+            {{- if eq .Values.rbac.scope "namespaced" }}
+            {{- range .Values.rbac.watchNamespaces }}
+            - --watch-namespace={{ . }}
+            {{- end }}
+            {{- end }}
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/sonarqube-operator/templates/role.yaml
+++ b/charts/sonarqube-operator/templates/role.yaml
@@ -1,0 +1,52 @@
+{{- /*
+Per-namespace Role + RoleBinding generated when rbac.scope=namespaced. The
+manager picks the same set of namespaces up via --watch-namespace flags
+(see deployment.yaml), so its cache and its RBAC stay in sync.
+*/ -}}
+{{- if and .Values.rbac.create (eq .Values.rbac.scope "namespaced") -}}
+{{- range $ns := .Values.rbac.watchNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "sonarqube-operator.fullname" $ }}-manager
+  namespace: {{ $ns }}
+  labels:
+    {{- include "sonarqube-operator.labels" $ | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - persistentvolumeclaims
+      - secrets
+      - services
+    verbs: [create, delete, get, list, patch, update, watch]
+  - apiGroups: [apps]
+    resources:
+      - statefulsets
+    verbs: [create, delete, get, list, patch, update, watch]
+  - apiGroups: [batch]
+    resources:
+      - cronjobs
+    verbs: [create, delete, get, list, patch, update, watch]
+  - apiGroups: [networking.k8s.io]
+    resources:
+      - ingresses
+    verbs: [create, delete, get, list, patch, update, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "sonarqube-operator.fullname" $ }}-manager
+  namespace: {{ $ns }}
+  labels:
+    {{- include "sonarqube-operator.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "sonarqube-operator.fullname" $ }}-manager
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sonarqube-operator.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/sonarqube-operator/values.yaml
+++ b/charts/sonarqube-operator/values.yaml
@@ -153,6 +153,29 @@ rbac:
   create: true
   # -- Create the user-facing aggregated ClusterRoles (admin / editor / viewer).
   createAggregatedRoles: true
+  # -- Scope of the operator's RBAC on core resources (Secrets, Services,
+  # PVCs, StatefulSets, Ingresses, CronJobs).
+  #
+  # `cluster` (default): one ClusterRole grants every verb on every namespace —
+  # easiest install, widest blast radius. Backwards compatible with releases
+  # before this option existed.
+  #
+  # `namespaced`: ClusterRole keeps only the CRD verbs (the operator must
+  # watch the CRDs cluster-wide), and a Role + RoleBinding are generated in
+  # each namespace listed under `rbac.watchNamespaces`. The manager is also
+  # started with `--watch-namespace=...` so its cache matches its RBAC.
+  scope: cluster
+  # -- Namespaces the operator is allowed to reconcile in when
+  # `rbac.scope=namespaced`. Each one gets a Role + RoleBinding granting the
+  # operator the same verbs the cluster-scoped ClusterRole would carry, and
+  # the manager pod gets a matching `--watch-namespace` flag.
+  #
+  # Ignored when `rbac.scope=cluster`. Required when `rbac.scope=namespaced`
+  # — an empty list with namespaced scope produces an operator that can
+  # watch nothing and the chart will fail at render time.
+  watchNamespaces: []
+  # - sonarqube
+  # - team-a
 
 crds:
   # -- Validate that CRDs are installed. Helm 3 installs files under crds/

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -65,6 +66,7 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var watchNamespaces stringSliceFlag
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -87,6 +89,8 @@ func main() {
 		"If set, the validating webhook server will be started. Requires TLS certificates (e.g. via cert-manager).")
 	flag.IntVar(&webhookPort, "webhook-port", 9443,
 		"The port the validating webhook server binds to. Must match the targetPort of the webhook Service.")
+	flag.Var(&watchNamespaces, "watch-namespace",
+		"Namespace to watch CRs in. Repeat to watch multiple namespaces. Empty (default) watches all namespaces — pair with rbac.scope=namespaced in the chart to restrict the operator's RBAC to the same set.")
 	// Production-friendly defaults: JSON encoding, structured stack traces only
 	// on errors, sane sampling. Override at deploy time with --zap-devel for the
 	// verbose human-readable console output suited to local `make run`.
@@ -163,6 +167,19 @@ func main() {
 		metricsServerOptions.KeyName = metricsCertKey
 	}
 
+	cacheOpts := cache.Options{}
+	if len(watchNamespaces) > 0 {
+		// Restrict the manager's cache (and therefore every controller's
+		// list/watch) to the requested namespaces. The operator's RBAC
+		// must allow it — see chart values rbac.scope and
+		// rbac.watchNamespaces.
+		cacheOpts.DefaultNamespaces = make(map[string]cache.Config, len(watchNamespaces))
+		for _, ns := range watchNamespaces {
+			cacheOpts.DefaultNamespaces[ns] = cache.Config{}
+		}
+		setupLog.Info("Restricting watched namespaces", "namespaces", []string(watchNamespaces))
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
@@ -175,6 +192,7 @@ func main() {
 		// waiting for the full LeaseDuration. Safe here because the manager exits
 		// cleanly via signal handling with no post-stop work.
 		LeaderElectionReleaseOnCancel: true,
+		Cache:                         cacheOpts,
 	})
 	if err != nil {
 		setupLog.Error(err, "Failed to start manager")
@@ -320,4 +338,28 @@ func main() {
 		setupLog.Error(err, "Failed to run manager")
 		os.Exit(1)
 	}
+}
+
+// stringSliceFlag accumulates a repeatable string flag, so users can pass
+// `--watch-namespace foo --watch-namespace bar` instead of relying on a CSV
+// convention. flag.Var requires implementing String() and Set().
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string {
+	if s == nil {
+		return ""
+	}
+	out := ""
+	for i, v := range *s {
+		if i > 0 {
+			out += ","
+		}
+		out += v
+	}
+	return out
+}
+
+func (s *stringSliceFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -90,7 +91,9 @@ func main() {
 	flag.IntVar(&webhookPort, "webhook-port", 9443,
 		"The port the validating webhook server binds to. Must match the targetPort of the webhook Service.")
 	flag.Var(&watchNamespaces, "watch-namespace",
-		"Namespace to watch CRs in. Repeat to watch multiple namespaces. Empty (default) watches all namespaces — pair with rbac.scope=namespaced in the chart to restrict the operator's RBAC to the same set.")
+		"Namespace to watch CRs in. Repeat to watch multiple namespaces. "+
+			"Empty (default) watches all namespaces — pair with rbac.scope=namespaced "+
+			"in the chart to restrict the operator's RBAC to the same set.")
 	// Production-friendly defaults: JSON encoding, structured stack traces only
 	// on errors, sane sampling. Override at deploy time with --zap-devel for the
 	// verbose human-readable console output suited to local `make run`.
@@ -349,14 +352,7 @@ func (s *stringSliceFlag) String() string {
 	if s == nil {
 		return ""
 	}
-	out := ""
-	for i, v := range *s {
-		if i > 0 {
-			out += ","
-		}
-		out += v
-	}
-	return out
+	return strings.Join(*s, ",")
 }
 
 func (s *stringSliceFlag) Set(value string) error {

--- a/docs/operations/multi-tenancy.md
+++ b/docs/operations/multi-tenancy.md
@@ -96,11 +96,47 @@ SonarQube server but you still want to know exactly who can talk to it.
 the pre-gate behavior. Use only when every namespace in the cluster is
 trusted equally — typically a single-tenant cluster.
 
-**One operator per tenant namespace**. The operator can be installed
-multiple times in scoped namespaces (`--watch-namespace=team-a` in a
-future release; for now, one Helm release per namespace works). This
-is the strongest isolation but adds operational overhead — consider it
-for hard regulatory boundaries only.
+**One operator per tenant namespace**. Strongest isolation: install the
+chart once per namespace, each release watches only its own. See
+[Narrowing the operator's RBAC](#narrowing-the-operators-rbac) below
+for the supported way to do this with the chart.
+
+## Narrowing the operator's RBAC
+
+By default the operator's ClusterRole grants full access to `secrets`,
+`services`, `persistentvolumeclaims`, `statefulsets`, `ingresses`, and
+`batch/cronjobs` cluster-wide — convenient at install time, widest
+possible blast radius. The chart exposes a tighter mode:
+
+```yaml
+rbac:
+  scope: namespaced
+  watchNamespaces:
+    - sonarqube
+    - team-a
+    - team-b
+```
+
+In `namespaced` mode the chart:
+
+- Keeps a ClusterRole, but with **only** the CRD verbs — the operator
+  must watch the `sonarqube.sonarqube.io` types cluster-wide for the
+  cache to function.
+- Generates a `Role` + `RoleBinding` in each namespace listed under
+  `watchNamespaces`, granting the same core-resource verbs the
+  cluster-scoped ClusterRole would have carried.
+- Passes `--watch-namespace=<ns>` to the manager for each entry, so
+  the controller-runtime cache and the RBAC stay in lockstep — the
+  operator literally cannot list / get / patch outside the listed
+  namespaces.
+
+Setting `rbac.scope=namespaced` with an empty `watchNamespaces` fails
+at chart render time with a clear error.
+
+The default stays `cluster` to preserve backwards compatibility with
+existing installs. Switch to `namespaced` once you've identified every
+namespace your Instances live in — typically as part of moving from a
+single shared SonarQube to per-team Instances.
 
 ## What the gate does *not* protect against
 


### PR DESCRIPTION
## Summary

Adds an opt-in tighter RBAC mode. `cluster` stays the default — zero behaviour change for existing installs — but operators that know which namespaces hold their Instances can now switch to `namespaced` and shrink the operator's blast radius to those namespaces.

## How it works

\`\`\`yaml
rbac:
  scope: namespaced       # default: cluster
  watchNamespaces:
    - sonarqube
    - team-a
    - team-b
\`\`\`

When set:

- ClusterRole keeps **only** the CRD verbs (\`sonarqube.sonarqube.io/*\`) — required for the cluster-wide CRD watch.
- A \`Role\` + \`RoleBinding\` is generated in each \`watchNamespaces\` entry, granting the same core-resource verbs the cluster-scoped ClusterRole would have.
- The manager pod gets one \`--watch-namespace=<ns>\` flag per entry, wiring \`cache.Options.DefaultNamespaces\` so the controller-runtime cache exactly matches the new RBAC — the operator literally cannot list / get / patch outside the listed namespaces.

Setting \`rbac.scope=namespaced\` with an empty \`watchNamespaces\` fails at \`helm template\` time with a clear error pointing to the doc.

## Changes

- \`cmd/main.go\` — new \`--watch-namespace\` repeatable flag and \`stringSliceFlag\` type, wired to \`cache.Options.DefaultNamespaces\`
- \`charts/sonarqube-operator/values.yaml\` — \`rbac.scope\` and \`rbac.watchNamespaces\` documented
- \`charts/sonarqube-operator/templates/clusterrole.yaml\` — drop core resources when \`scope=namespaced\`, fail render when watchNamespaces empty
- \`charts/sonarqube-operator/templates/role.yaml\` — new, generates Role+RoleBinding per namespace
- \`charts/sonarqube-operator/templates/deployment.yaml\` — append \`--watch-namespace\` args from \`watchNamespaces\`
- \`docs/operations/multi-tenancy.md\` — new \"Narrowing the operator's RBAC\" section

## Test plan

- [x] \`helm lint\` clean for both \`cluster\` and \`namespaced\` (with namespaces)
- [x] \`helm template\` with \`scope=namespaced\` and empty list fails with the expected message
- [x] \`helm template\` rendering for two namespaces produces one Role + one RoleBinding per namespace
- [x] \`go build\`, \`go vet\`, \`go test ./api/...\` green
- [ ] CI green on this PR
- [ ] Manual: deploy with \`scope=namespaced, watchNamespaces=[sonarqube]\`, create an Instance in another namespace, observe the operator does not pick it up

## Related issues

Closes #48