### PR TITLE
chore: governance + CI matrix + roadmap refresh for v1.0 launch prep

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners for the SonarQube Operator.
+#
+# The owner is automatically requested for review on every pull request
+# touching a matching path. See:
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo.
+*       @BEIRDINH0S

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+version: 2
+updates:
+  # Go module dependencies (controller-runtime, client-go, etc.).
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # Base images referenced from the Dockerfile.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -6,9 +6,29 @@ on:
 
 jobs:
   test-e2e:
-    name: Run on Ubuntu
+    name: Run on K8s ${{ matrix.k8s }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        # kindest/node digests are pinned per kind release; bump the kind
+        # version below in lock-step when refreshing this matrix. See
+        # https://github.com/kubernetes-sigs/kind/releases.
+        k8s:
+          - "1.28"
+          - "1.29"
+          - "1.30"
+          - "1.31"
+        include:
+          - k8s: "1.28"
+            node-image: "kindest/node:v1.28.15"
+          - k8s: "1.29"
+            node-image: "kindest/node:v1.29.10"
+          - k8s: "1.30"
+            node-image: "kindest/node:v1.30.6"
+          - k8s: "1.31"
+            node-image: "kindest/node:v1.31.2"
 
     steps:
       - name: Checkout
@@ -22,7 +42,8 @@ jobs:
 
       - name: Install Kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)
+          KIND_VERSION=v0.25.0
+          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-$(go env GOARCH)"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 
@@ -30,6 +51,8 @@ jobs:
         run: kind version
 
       - name: Run e2e tests
+        env:
+          KIND_NODE_IMAGE: ${{ matrix.node-image }}
         run: |
           go mod tidy
           make test-e2e
@@ -37,6 +60,8 @@ jobs:
       - name: Collect debug info on failure
         if: failure()
         run: |
+          echo "=== K8s version ==="
+          kubectl version || true
           echo "=== All pods ==="
           kubectl get pods -A || true
           echo "=== Operator logs ==="

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 BEIRDINH0S
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,11 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation." ;; \
 		*) \
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
-			$(KIND) create cluster --name $(KIND_CLUSTER) --config kind-config.yaml ;; \
+			if [ -n "$(KIND_NODE_IMAGE)" ]; then \
+				$(KIND) create cluster --name $(KIND_CLUSTER) --config kind-config.yaml --image "$(KIND_NODE_IMAGE)"; \
+			else \
+				$(KIND) create cluster --name $(KIND_CLUSTER) --config kind-config.yaml; \
+			fi ;; \
 	esac
 
 .PHONY: test-e2e

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,11 +5,13 @@ where it is going. For the full per-CRD task list, see the
 [GitHub issues](https://github.com/BEIRDINH0S/sonarqube-operator/issues)
 and the [Releases page](https://github.com/BEIRDINH0S/sonarqube-operator/releases).
 
-> **Current status**: late beta. Ten CRDs ship — eight with full
-> reconcile loops, two (`SonarQubeBranchRule`, `SonarQubeBackup`) as
-> admission-only scaffolds. The API is in `v1alpha1` and may change
-> before `v1.0.0` — see the changelog for migration notes between
-> releases.
+> **Current status**: `v0.5.0` shipped — first stable line. Ten CRDs ship,
+> eight with full reconcile loops, two (`SonarQubeBranchRule`,
+> `SonarQubeBackup`) as admission-only scaffolds. The API is still in
+> `v1alpha1` and may break in the `v1beta1` promotion that precedes
+> `v1.0.0`; conversion webhooks will be introduced at that point so users
+> on `v1alpha1` get a clean upgrade path. See the changelog for migration
+> notes between releases.
 
 ---
 
@@ -34,74 +36,94 @@ and the [Releases page](https://github.com/BEIRDINH0S/sonarqube-operator/release
   with managed-set ownership tracking.
 - **Production hardening** — leader election, validating webhook
   (opt-in), Prometheus metrics, rate-limited reconcile, batched
-  SonarQube restarts on plugin install/uninstall.
+  SonarQube restarts on plugin install/uninstall, JSON-structured logs
+  by default, webhook port plumbed through the chart, CI-token churn
+  fix, project main-branch sync surfaced as a status condition.
+- **Multi-tenancy** — opt-in cross-namespace `instanceRef` allowlist
+  with a validating webhook, RBAC namespaced mode that scopes the
+  operator to a list of namespaces, documented threat model.
 - **Packaging** — multi-arch image (amd64+arm64) on GHCR with SBOM and
   SLSA provenance, Helm chart published as OCI artifact, single-file
   `install.yaml` for `kubectl apply`, GitOps-friendly (Argo CD / Flux
   examples in the docs).
+- **Quality gates** — `golangci-lint` clean, 60% coverage floor enforced
+  in CI, end-to-end suite covering the full Quick Start including a
+  real `sonar-scanner` analysis against the operator-managed instance.
 - **Documentation** — full MkDocs site at
   [beirdinh0s.github.io/sonarqube-operator](https://beirdinh0s.github.io/sonarqube-operator/)
   covering Getting Started, How-To, Reference (per CRD + Helm values +
   metrics), Operations, and Contributing.
+- **Governance** — `LICENSE` (Apache 2.0), `SECURITY.md`, `SUPPORT.md`,
+  `CODE_OF_CONDUCT.md`, `CODEOWNERS`.
 
 ---
 
-## In flight (toward `v0.5.0` stable)
+## In flight (toward `v1.0.0`)
 
-- **Hardening fixes** identified during code review and first cluster
-  validation:
-  - P0 (release-blocking): chart image lowercase ✅, finalizer-deletion
-    ordering ✅, child controllers using `Status.URL` ✅. All shipped
-    in commits leading up to `v0.5.0-rc.3`.
-  - P1: webhook port plumbing, multi-tenancy threat model, CI token
-    churn risk on `Update` failure.
-  - P2/P3: README polish, structured logs by default, Go version
-    consistency, RBAC scoping, lint/test coverage thresholds.
-- **User validation on a real cluster** — running through the Quick
-  Start end-to-end on a non-CI cluster, with a real `sonar-scanner`
-  analysis. The first iteration already turned up the `Status.URL` bug.
+The work between `v0.5.0` and `v1.0.0` is grouped into four tracks. They
+move in parallel; nothing here strictly depends on anything else except
+where called out.
 
-When all P0+P1 items and validation are green, we cut `v0.5.0` stable.
+### API stabilization
 
----
+- Promote `v1alpha1` → `v1beta1` with a final field-by-field audit
+  before the schema gets harder to change.
+- Wire conversion webhooks (kubebuilder hub-and-spoke, `v1beta1` as the
+  hub) so existing `v1alpha1` resources keep working through the cut.
+- Publish a deprecation policy: minimum support window for a stored
+  version, how breaking changes get announced, when fields can be
+  removed.
+- Once `v1beta1` has soaked, promote to `v1` and freeze the schema.
 
-## Coming next (toward `v1.0.0`)
+### Surface completeness
 
-- **API stabilization** — promote `v1alpha1` to `v1beta1` and then `v1`,
-  with conversion webhooks and a public deprecation policy.
-- **OperatorHub.io listing** — package as an OLM bundle and submit a PR
-  to the `community-operators` repo.
-- **Artifact Hub indexing** for the Helm chart.
-- **Supply-chain hardening** — Cosign signing of release artifacts,
-  `SECURITY.md`, OpenSSF Scorecard.
-- **Cross-version K8s testing** — CI matrix across the supported
-  Kubernetes minors (currently 1.27+).
-- **Community & governance** — `CODE_OF_CONDUCT.md`, `SUPPORT.md`,
-  issue/PR templates, `CODEOWNERS`, GitHub Discussions.
+- Decide on the two scaffold CRDs (`SonarQubeBranchRule`,
+  `SonarQubeBackup`) before `v1.0.0`: either implement the reconcile
+  pipelines, or remove them from the documented surface and ship them
+  in a later minor. A "stable v1.0" that is 20% admission-only is not
+  the right story.
+- Two-StatefulSet DCE rendering driven by `spec.cluster` (Instance).
+- Webhook drift correction (delete + recreate when URL or HMAC secret
+  diverges).
 
-`v1.0.0` is published once these pieces land and the project has been
-running in production with at least a handful of external users.
+### Distribution & supply chain
+
+- Cosign signing of `install.yaml`, the Helm chart OCI artifact, and
+  the GHCR image.
+- [Artifact Hub](https://artifacthub.io/) indexing for the Helm chart.
+- [OperatorHub.io](https://operatorhub.io/) listing as an OLM bundle
+  (`operator-sdk generate bundle`, PR to
+  `k8s-operatorhub/community-operators`).
+- OpenSSF Scorecard workflow + badge on the README.
+- CI matrix across the supported Kubernetes minors.
+
+### Validation
+
+- Real-cluster validation by external users — at least a handful of
+  independent operators running through the Quick Start and reporting
+  back. Bug reports from real environments are the only way to find
+  out what is genuinely broken before the API freezes.
+
+`v1.0.0` is published once these tracks land and the project has been
+running without regressions on `v1beta1` for at least one minor cycle.
 
 ---
 
 ## Beyond `v1.0.0` (nice-to-have)
 
-- OpenTelemetry tracing through the Reconcile loop
-- OpenShift-specific testing and SCC packaging
-- Mutation / fuzz / soak testing
-- **Reconcile pipelines for the scaffold CRDs**:
+- OpenTelemetry tracing through the Reconcile loop.
+- OpenShift-specific testing and SCC packaging.
+- Mutation / fuzz / soak testing.
+- **Reconcile pipelines for the scaffold CRDs** if they were not
+  shipped with `v1.0.0`:
   - `SonarQubeBranchRule` — actual calls to `/api/new_code_periods/set`,
     `/api/qualitygates/select`, `/api/settings/set` scoped to a branch.
   - `SonarQubeBackup` — materialize a `CronJob` running `pg_dump` +
     extensions snapshot, ship to PVC/S3, retention pruning.
-- **Instance** — true two-StatefulSet (app + search) DCE rendering
-  driven by `spec.cluster`.
 - **Permission templates** — surface `spec.permissions[]` on
   `SonarQubePermissionTemplate` so template grants can be declared as
   code (today they are managed in the SonarQube UI even when the
   template itself is operator-managed).
-- **Webhook drift correction** — delete + re-create when URL or HMAC
-  secret diverges from the spec.
 - A `SonarQubeRestore` CRD orchestrating the inverse of
   `SonarQubeBackup`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in the SonarQube
+Operator, please **do not** open a public GitHub issue. Public disclosure
+before a fix is available puts every cluster running this operator at risk.
+
+Instead, report it privately via one of the following:
+
+- **GitHub Security Advisory** (preferred):
+  <https://github.com/BEIRDINH0S/sonarqube-operator/security/advisories/new>
+- **Email**: erwan.mathieu30@gmail.com — please prefix the subject with
+  `[security][sonarqube-operator]`.
+
+Please include:
+
+- A description of the issue and its impact.
+- Reproduction steps, ideally with a minimal manifest set.
+- The operator version (`helm list` or image tag), the Kubernetes version,
+  and any relevant cluster configuration (RBAC mode, webhook enabled, etc.).
+- Any proof-of-concept exploit you are willing to share.
+
+## Response
+
+| Stage | Target |
+|---|---|
+| Acknowledgement | Within 3 business days |
+| Triage and severity assessment | Within 7 business days |
+| Patch availability for confirmed High/Critical issues | Within 30 days |
+
+You will get progress updates at each stage. If you do not hear back within
+the acknowledgement window, please re-send via the alternate channel above.
+
+## Disclosure
+
+The default disclosure model is **coordinated disclosure**: we will agree on
+a public-disclosure date with the reporter, ship the patch, publish a
+[GitHub Security Advisory](https://github.com/BEIRDINH0S/sonarqube-operator/security/advisories),
+and request a CVE where appropriate. Reporters are credited in the advisory
+unless they ask to remain anonymous.
+
+## Supported Versions
+
+Only the latest stable minor receives security fixes. Older minors may be
+patched on a case-by-case basis for High or Critical issues; everything else
+should be addressed by upgrading.
+
+| Version | Supported |
+|---|---|
+| 0.5.x   | ✅ Latest stable — security fixes |
+| < 0.5   | ❌ Pre-release, no longer maintained |
+
+Once `v1.0.0` ships, this table will be updated to reflect the supported
+window for the stable line (typically the latest two minors).
+
+## Scope
+
+This policy covers the operator itself: the controller manager, the CRDs and
+their reconcile logic, the validating webhook, the Helm chart, and the
+release artifacts published to GHCR.
+
+It does **not** cover SonarQube itself — vulnerabilities in SonarQube Server
+should be reported to [SonarSource](https://www.sonarsource.com/security/).
+
+## Out of Scope
+
+- Issues that require an attacker who already has cluster-admin or who can
+  edit the operator's own Deployment / RBAC.
+- Denial-of-service caused by a user creating a very large number of CRs in
+  a namespace they already control.
+- Findings from automated scanners without a working proof-of-concept.
+
+Thank you for helping keep the project — and the people running it — safe.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,70 @@
+# Getting Help
+
+Thanks for using the SonarQube Operator. This page lists where to ask
+what — picking the right channel gets you a useful answer faster.
+
+## Questions and discussion
+
+For "how do I…", "is this the right way to…", design questions, or
+ideas you want to bounce around before opening an issue:
+
+- **GitHub Discussions** — <https://github.com/BEIRDINH0S/sonarqube-operator/discussions>
+
+Search first. A lot of the early questions are already answered there
+or in the docs.
+
+## Documentation
+
+The full documentation site lives at
+<https://beirdinh0s.github.io/sonarqube-operator/>:
+
+- **Getting Started** — install on kind, first `SonarQubeInstance`,
+  Quick Start with `sonar-scanner`.
+- **How-To** — task-oriented guides for each CRD.
+- **Reference** — every CRD field, Helm value, and exposed metric.
+- **Operations** — upgrades, multi-tenancy, RBAC scoping, backups.
+- **Contributing** — how to build, test, and submit changes.
+
+If something is missing or unclear, that itself is worth a
+[Discussion](https://github.com/BEIRDINH0S/sonarqube-operator/discussions)
+or a docs PR.
+
+## Bug reports and feature requests
+
+Open a [GitHub issue](https://github.com/BEIRDINH0S/sonarqube-operator/issues/new/choose)
+when you have:
+
+- A reproducible bug — include the operator version, Kubernetes
+  version, the relevant CR YAML, the controller logs, and what you
+  expected vs. what happened.
+- A concrete feature request — describe the problem you are trying to
+  solve, not just the solution. Real use cases beat abstract wishes.
+
+Issues without a clear reproduction or use case may be moved to
+Discussions.
+
+## Security issues
+
+**Do not open a public issue for security vulnerabilities.** Follow the
+process documented in [SECURITY.md](SECURITY.md) (private GitHub
+Security Advisory or email).
+
+## What this project does not support
+
+- **SonarQube itself** — bugs in SonarQube Server, Community/Developer/
+  Enterprise editions, scanners, or the Marketplace go to
+  [SonarSource](https://community.sonarsource.com/). The operator only
+  drives SonarQube via its public API.
+- **Custom forks** — issues are triaged against the latest released
+  version on `main`. If you have patched the operator locally, please
+  reproduce on an unmodified release first.
+- **Commercial support contracts** — none today. The project is
+  maintained on a best-effort basis.
+
+## Response expectations
+
+This is a community project. Triage typically happens within a week,
+sometimes faster. Security reports follow the SLA in
+[SECURITY.md](SECURITY.md). Everything else moves at the speed of
+volunteers — pull requests are the most reliable way to get something
+fixed.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,158 @@
 # Changelog
 
-The authoritative changelog lives on the [GitHub Releases page](https://github.com/BEIRDINH0S/sonarqube-operator/releases),
-where every tag publishes auto-generated release notes alongside the
-`install.yaml` and Helm chart artifacts.
+All notable changes to the SonarQube Operator are documented in this file.
 
-A curated, human-edited changelog will be added here once the project reaches
-`v1.0.0`.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Per-tag release notes (auto-generated commit log, `install.yaml`, Helm
+chart artifacts, SBOM, SLSA attestation) live on the
+[GitHub Releases page](https://github.com/BEIRDINH0S/sonarqube-operator/releases).
+
+> **API stability**: the API is currently `v1alpha1` and will break at
+> least once before `v1.0.0`, when it is promoted to `v1beta1`.
+> Conversion webhooks will be added at the `v1beta1` cut so existing
+> resources keep working through the upgrade. Each release below
+> documents migration notes when relevant.
+
+## [Unreleased]
+
+### Added
+
+- `LICENSE` (Apache 2.0), `SUPPORT.md`, `CODE_OF_CONDUCT.md`,
+  `CODEOWNERS`, and a Dependabot configuration — governance pieces
+  required before the public `v1.0.0` launch.
+- Cross-version Kubernetes CI matrix (1.28, 1.29, 1.30, 1.31) on the
+  end-to-end suite.
+
+## [0.5.0] — 2026-04-26
+
+First stable line. Closes the post-RC hardening punch list and the
+multi-tenancy story, ships the full Quick Start in CI.
+
+### Added
+
+- **Multi-tenancy** — opt-in cross-namespace `instanceRef` allowlist
+  with a validating webhook, RBAC namespaced mode that scopes the
+  operator to a list of namespaces, documented threat model in
+  `docs/operations`.
+- **End-to-end Quick Start in CI** — the e2e suite now installs the
+  operator, provisions a `SonarQubeInstance`, projects, and users, and
+  runs a real `sonar-scanner` analysis against the operator-managed
+  instance.
+- **CI-side SonarQube analysis** — every PR and `main` push is scanned
+  against the operator-managed SonarQube.
+- **Coverage floor** — `make check-coverage` enforces 60% in CI
+  (`COVERAGE_THRESHOLD` in the Makefile).
+
+### Changed
+
+- **JSON-structured logs by default** in production builds; text logs
+  remain available behind a flag for local development.
+- **README** rewritten to reflect the 10-CRD surface, the new status
+  conditions, the webhook-port plumbing, and JSON logs.
+
+### Fixed
+
+- **`SonarQubeInstance`** — surface a `Degraded` condition listing the
+  scaffold-only spec fields that are set but not yet reconciled
+  (`spec.cluster`, `spec.monitoring`).
+- **`SonarQubeProject`** — main-branch sync failures are now reported
+  via the `MainBranchSynced` condition with a specific reason instead
+  of being silently retried.
+- **`SonarQubeProject`** — CI tokens no longer churn when the
+  `rotate-token` annotation is cleared after an `Update` failure.
+- **`SonarQubeUser`** — own the token `Secret` objects (so deletion
+  cascades correctly) and skip global permissions that are already
+  granted upstream.
+- **Manager / chart** — webhook port plumbed all the way through the
+  controller manager and the Helm chart so a non-default port works.
+- **Packaging** — `install.yaml`, chart RBAC, and samples now cover
+  all 10 CRDs; previously the extended ones were missing in some
+  artefacts.
+
+### Security
+
+- Validating webhook entries for the cross-namespace `instanceRef`
+  gate exposed in the chart so the multi-tenancy boundary is enforced
+  by default when the chart is rendered with `multiTenant=true`.
+
+## [0.5.0-rc.2] — 2026-04-25
+
+### Added
+
+- Full MkDocs Material documentation site published at
+  <https://beirdinh0s.github.io/sonarqube-operator/> — Getting Started,
+  How-To, Reference, Operations, Contributing.
+- Reference pages for every CRD field, every Helm value, every exposed
+  metric.
+
+### Fixed
+
+- **P0** — chart image references lowercased (some registries reject
+  mixed case).
+- **P0** — finalizer-deletion ordering corrected so child resources are
+  removed before their owning CR's finalizer is dropped.
+
+## [0.5.0-rc.1] — 2026-04-25
+
+First release candidate. Ships the full 10-CRD surface and the release
+pipeline.
+
+### Added
+
+- **Five new CRDs** since the previous milestone:
+  - `SonarQubeGroup` — drift-corrected groups.
+  - `SonarQubePermissionTemplate` — applied automatically by
+    project-key pattern.
+  - `SonarQubeWebhook` — project-scoped or global webhooks
+    (HMAC-signed).
+  - `SonarQubeBranchRule` — admission-only scaffold (reconcile
+    pipeline tracked as a follow-up).
+  - `SonarQubeBackup` — admission-only scaffold (reconcile pipeline
+    tracked as a follow-up).
+- **Instance enrichment** — `nodeSelector`, `tolerations`, `affinity`,
+  `podSecurityContext`, `securityContext`, ServiceMonitor scaffold,
+  DCE topology spec field (`spec.cluster`, single-StatefulSet rendering
+  today).
+- **Project enrichment** — `tags`, `links`, `settings`, `permissions`
+  with managed-set ownership tracking.
+- **User enrichment** — `scmAccounts`, standalone `tokens` (with
+  `USER_TOKEN` and `GLOBAL_ANALYSIS_TOKEN`), `globalPermissions` with
+  managed-set ownership tracking.
+- **Token rotation** for `SonarQubeProject` CI tokens.
+- **Production hardening** — leader election, validating webhooks
+  (opt-in), Prometheus metrics, rate-limited reconcile, batched
+  SonarQube restarts on plugin install/uninstall, version-downgrade
+  webhook.
+- **Packaging** — multi-arch image (`amd64`, `arm64`) on GHCR with
+  SBOM and SLSA provenance, Helm chart published as an OCI artifact,
+  single-file `install.yaml` for `kubectl apply`, Argo CD / Flux
+  examples in the docs.
+- **Release workflow** in GitHub Actions — tagged release builds the
+  image, signs nothing yet (Cosign deferred to `v1.0.0`), publishes
+  the chart and `install.yaml`.
+
+### Fixed
+
+- Lowercase OCI references for `helm push` and `install.yaml`.
+- Pre-release tag handling in the release workflow.
+- SonarQube 10.x API compatibility — migrated `DeleteQualityGate` to
+  REST v2.
+- StatefulSet full-update path, sysctl init-container, calibrated
+  probes.
+- Token-auth handling, `ErrNotFound` propagation, visibility drift
+  correction.
+
+## [Pre-0.5.0]
+
+Initial kubebuilder scaffold through Phase 5: `SonarQubeInstance`,
+`SonarQubePlugin`, `SonarQubeProject`, `SonarQubeQualityGate`,
+`SonarQubeUser` controllers, the SonarQube API client, the unit and
+integration test harness, and the early e2e suite. Tracked on the
+[Releases page](https://github.com/BEIRDINH0S/sonarqube-operator/releases)
+for the historical commit log.
+
+[Unreleased]: https://github.com/BEIRDINH0S/sonarqube-operator/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/BEIRDINH0S/sonarqube-operator/releases/tag/v0.5.0
+[0.5.0-rc.2]: https://github.com/BEIRDINH0S/sonarqube-operator/releases/tag/v0.5.0-rc.2
+[0.5.0-rc.1]: https://github.com/BEIRDINH0S/sonarqube-operator/releases/tag/v0.5.0-rc.1


### PR DESCRIPTION
## Summary

Phase A of the v1.0 launch prep — the credibility and governance pieces a public project needs before a public-launch milestone, plus the CI matrix groundwork. Three logical commits:

1. **`chore: add LICENSE and governance files`** — `LICENSE` (Apache-2.0, the README claimed it but no file existed), `SECURITY.md` (private GHSA + email, response SLA, supported-version table), `SUPPORT.md` (Discussions / Issues / docs / SECURITY routing), `.github/CODEOWNERS`. `CODE_OF_CONDUCT.md` is intentionally **deferred to a follow-up commit**.
2. **`docs: refresh ROADMAP and curate changelog`** — `ROADMAP.md` was stuck on `late beta, in flight toward v0.5.0 stable` even though `v0.5.0` is tagged and the entire P1/P2/P3 hardening list landed; rewrite around the four `v1.0` tracks (API stabilization, surface completeness, distribution, validation). `docs/changelog.md` replaces the `coming at v1.0` stub with a Keep-a-Changelog history (`v0.5.0`, `v0.5.0-rc.2`, `v0.5.0-rc.1`, `Pre-0.5.0`) and an `Unreleased` section.
3. **`ci: K8s matrix + Dependabot`** — e2e runs across 1.28 / 1.29 / 1.30 / 1.31 instead of `kindest/node:latest`; pin kind `v0.25.0` and a digest per minor. `Makefile setup-test-e2e` now honors `KIND_NODE_IMAGE` (local `make test-e2e` unchanged). `.github/dependabot.yml` adds weekly gomod / github-actions / docker updates.

## Why now

The ROADMAP advertised `v1.0` as the launch milestone. The repo was missing the basic legal (`LICENSE`) and governance (`SECURITY.md`, `SUPPORT.md`, `CODEOWNERS`) files that GHCR / OperatorHub.io / corporate users will all eventually require. Same logic for the CI matrix — controller-runtime / client-go skew across K8s minors is the kind of thing you only catch when you actually run against several minors. None of this blocks `v0.5.x` users; all of it is required before the `v1.0` cut.

## What is intentionally **not** in this PR

- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1) — deferred, will land in a separate small commit. Tracking on the branch.
- API promotion `v1alpha1` → `v1beta1` + conversion webhooks — the big v1.0 chunk; out of scope here.
- Cosign signing, Artifact Hub, OperatorHub.io OLM bundle, OpenSSF Scorecard — Phase C, separate PRs.
- Decision on the two scaffold CRDs (`SonarQubeBranchRule`, `SonarQubeBackup`) — Phase B, separate.

## Test plan

- [ ] CI green on the new matrix (`test-e2e` × 1.28 / 1.29 / 1.30 / 1.31)
- [ ] `lint`, `test`, `coverage`, `sonar-analysis`, `docs` workflows still green
- [ ] `LICENSE` rendered on the GitHub repo landing page (auto-detected as Apache-2.0)
- [ ] `SECURITY.md` surfaces in the **Security** tab and the private-advisory link works
- [ ] Visual check on rendered `ROADMAP.md` and `docs/changelog.md` (MkDocs build)
- [ ] Dependabot opens its first PRs after merge — sanity-check the grouping (`k8s.io/*`, `sigs.k8s.io/*`, `go.opentelemetry.io/*`)